### PR TITLE
fix: MainScreenの主要操作にaccessibilityLabelを追加

### DIFF
--- a/app/src/components/CustomSlider.tsx
+++ b/app/src/components/CustomSlider.tsx
@@ -11,6 +11,8 @@ interface CustomSliderProps {
   maximumTrackTintColor?: string;
   thumbTintColor?: string;
   style?: ViewStyle;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
 }
 
 const CustomSlider: React.FC<CustomSliderProps> = ({
@@ -23,6 +25,8 @@ const CustomSlider: React.FC<CustomSliderProps> = ({
   maximumTrackTintColor = '#2a2a2a',
   thumbTintColor = '#ff4e50',
   style,
+  accessibilityLabel,
+  accessibilityHint,
 }) => {
   const trackWidth = useRef(0);
   const trackX = useRef(0);
@@ -74,7 +78,15 @@ const CustomSlider: React.FC<CustomSliderProps> = ({
   const ratio = isNaN(rawRatio) ? 0 : Math.min(1, Math.max(0, rawRatio));
 
   return (
-    <View ref={trackRef} style={[styles.container, style]} onLayout={onLayout} {...panResponder.panHandlers}>
+    <View
+      ref={trackRef}
+      style={[styles.container, style]}
+      onLayout={onLayout}
+      accessible
+      accessibilityRole="adjustable"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint={accessibilityHint}
+      {...panResponder.panHandlers}>
       <View style={styles.track}>
         <View style={[styles.trackFill, {flex: ratio, backgroundColor: minimumTrackTintColor}]} />
         <View style={[styles.trackEmpty, {flex: 1 - ratio, backgroundColor: maximumTrackTintColor}]} />

--- a/app/src/components/ResizeSlider.tsx
+++ b/app/src/components/ResizeSlider.tsx
@@ -84,6 +84,8 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
           </View>
           <CustomSlider
             style={styles.slider}
+            accessibilityLabel="リサイズ倍率スライダー"
+            accessibilityHint="1%から100%の範囲で画像サイズを変更します"
             minimumValue={1}
             maximumValue={100}
             step={1}

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -866,7 +866,9 @@ const MainScreen = () => {
                           styles.formatButton,
                           outputFormat === opt.value && styles.formatButtonActive,
                         ]}
-                        onPress={() => setOutputFormat(opt.value)}>
+                        onPress={() => setOutputFormat(opt.value)}
+                        accessibilityRole="button"
+                        accessibilityLabel={`出力フォーマット ${opt.label}`}>
                         <Text
                           style={[
                             styles.formatButtonText,
@@ -893,6 +895,8 @@ const MainScreen = () => {
                     step={1}
                     value={compressionRate}
                     onValueChange={(v: number) => handleQualityChange(Math.round(v))}
+                    accessibilityLabel="画像圧縮率スライダー"
+                    accessibilityHint="0%から99%の範囲で圧縮率を変更します"
                     minimumTrackTintColor={ACCENT2}
                     maximumTrackTintColor={BORDER}
                     thumbTintColor={ACCENT2}
@@ -929,6 +933,8 @@ const MainScreen = () => {
                     step={1}
                     value={shrinkExpandRate}
                     onValueChange={handleShrinkExpandRateChange}
+                    accessibilityLabel="縮小率スライダー"
+                    accessibilityHint="10%から90%の範囲で縮小率を変更します"
                     minimumTrackTintColor={ACCENT}
                     maximumTrackTintColor={BORDER}
                     thumbTintColor={ACCENT}
@@ -965,6 +971,8 @@ const MainScreen = () => {
                     step={1}
                     value={multiCompressCount}
                     onValueChange={handleMultiCompressCountChange}
+                    accessibilityLabel="多重圧縮回数スライダー"
+                    accessibilityHint="1回から10回の範囲で圧縮回数を変更します"
                     minimumTrackTintColor={ACCENT}
                     maximumTrackTintColor={BORDER}
                     thumbTintColor={ACCENT}
@@ -1049,14 +1057,18 @@ const MainScreen = () => {
             <TouchableOpacity
               style={[styles.saveButton]}
               onPress={handleSave}
-              activeOpacity={0.8}>
+              activeOpacity={0.8}
+              accessibilityRole="button"
+              accessibilityLabel="カメラロールに保存">
               <Text style={styles.buttonText}>カメラロールに保存</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
               style={[styles.shareButton]}
               onPress={handleShare}
-              activeOpacity={0.8}>
+              activeOpacity={0.8}
+              accessibilityRole="button"
+              accessibilityLabel="共有">
               <Text style={styles.buttonText}>🔗 共有</Text>
             </TouchableOpacity>
           </View>
@@ -1068,7 +1080,9 @@ const MainScreen = () => {
             style={[styles.processButton, (!selectedImage || isProcessing) && styles.disabledButton]}
             onPress={handleProcess}
             disabled={!selectedImage || isProcessing}
-            activeOpacity={0.8}>
+            activeOpacity={0.8}
+            accessibilityRole="button"
+            accessibilityLabel="ガビガビ化を実行">
             {isProcessing && processingAction === 'gabigabi' ? (
               <View style={styles.processingRow}>
                 <ActivityIndicator color="#fff" size="small" />
@@ -1083,7 +1097,9 @@ const MainScreen = () => {
             style={[styles.targetSizeProcessButton, (!selectedImage || isProcessing) && styles.disabledButton]}
             onPress={handleTargetSizeProcess}
             disabled={!selectedImage || isProcessing}
-            activeOpacity={0.8}>
+            activeOpacity={0.8}
+            accessibilityRole="button"
+            accessibilityLabel="指定サイズ以下に圧縮">
             {isProcessing && processingAction === 'targetSize' ? (
               <View style={styles.processingRow}>
                 <ActivityIndicator color="#fff" size="small" />


### PR DESCRIPTION
Fixes #26

## 変更内容
- 主要な操作ボタン（変換・サイズ圧縮・保存・共有）に accessibilityLabel / accessibilityRole を追加
- 出力フォーマット選択ボタンに accessibilityLabel を追加
- CustomSlider にアクセシビリティプロパティを追加し、Resize/圧縮率/縮小率/多重圧縮回数スライダーへラベルを設定

## 補足
- ローカル環境で test コマンド実行に必要な jest が未インストールのため、テスト実行は未実施です。