### PR TITLE
refactor: DISCORD_MAX_BYTESを共通定数へ移動

### DIFF
--- a/app/src/constants/limits.ts
+++ b/app/src/constants/limits.ts
@@ -1,0 +1,4 @@
+/**
+ * Discord の通常アップロード上限（10MB）。
+ */
+export const DISCORD_MAX_BYTES = 10 * 1024 * 1024;

--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -1,6 +1,7 @@
 import { FFmpegKit, FFprobeKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
 import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getPasslogConfig, getFileSizeBytes } from './ffmpegUtils';
+import { DISCORD_MAX_BYTES } from '../../constants/limits';
 
 export interface CompressResult {
   outputUri: string;
@@ -8,7 +9,6 @@ export interface CompressResult {
   compressionRatio: number;
 }
 
-const DISCORD_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
 
 /**
  * ファイルの拡張子から動画かどうかを判定する。


### PR DESCRIPTION
Fixes #4\n\n## 変更内容\n-  を追加し  を定義\n-  のローカル定数を削除し、共通定数を参照するよう変更\n\n## 確認\n- ローカルで  実行を試みたが、依存未インストール環境（jest未導入）で未実施