### PR TITLE
refactor: FileSizeLabelのexpo-file-system/legacy依存を除去

### DIFF
--- a/app/src/components/FileSizeLabel.tsx
+++ b/app/src/components/FileSizeLabel.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
-import * as FileSystem from 'expo-file-system/legacy';
+import * as FileSystem from 'expo-file-system';
 import { getFileSizeBytes } from '../data/ffmpeg/ffmpegUtils';
 
 interface FileSizeLabelProps {


### PR DESCRIPTION
Fixes #8\n\n## 変更内容\n-  の import を  から  へ移行\n- コンポーネント側の API 利用は互換のため変更なし