### PR TITLE
refactor: selectedMediaType を Zustand ストア管理へ移行

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -249,6 +249,7 @@ const MainScreen = () => {
   const insets = useSafeAreaInsets();
   const {
     selectedImage,
+    selectedMediaType,
     resizePercent,
     isProcessing,
     processedImage,
@@ -264,6 +265,7 @@ const MainScreen = () => {
     targetSizeValue,
     targetSizeUnit,
     setSelectedImage,
+    setSelectedMediaType,
     setResizePercent,
     setProcessedImage,
     setIsProcessing,
@@ -287,9 +289,6 @@ const MainScreen = () => {
   });
 
   const [processingAction, setProcessingAction] = useState<'gabigabi' | 'convert' | 'targetSize' | null>(null);
-
-  // #80: selected media type
-  const [selectedMediaType, setSelectedMediaType] = useState<'image' | 'video' | null>(null);
 
   // #77: fullscreen modal state
   const [fullscreenUri, setFullscreenUri] = useState<string | null>(null);

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -7,6 +7,7 @@ export type SizeUnit = 'KB' | 'MB' | 'GB';
 
 interface AppState {
   selectedImage: string | null;
+  selectedMediaType: 'image' | 'video' | null;
   resizePercent: number;
   processedImage: string | null;
   isProcessing: boolean;
@@ -24,6 +25,7 @@ interface AppState {
   targetSizeUnit: SizeUnit;
   
   setSelectedImage: (image: string | null) => void;
+  setSelectedMediaType: (mediaType: 'image' | 'video' | null) => void;
   setResizePercent: (percent: number) => void;
   setProcessedImage: (image: string | null) => void;
   setIsProcessing: (processing: boolean) => void;
@@ -43,6 +45,7 @@ interface AppState {
 
 export const useAppStore = create<AppState>(set => ({
   selectedImage: null,
+  selectedMediaType: null,
   resizePercent: 100,
   processedImage: null,
   isProcessing: false,
@@ -59,6 +62,7 @@ export const useAppStore = create<AppState>(set => ({
   targetSizeUnit: 'MB',
   
   setSelectedImage: image => set({selectedImage: image}),
+  setSelectedMediaType: mediaType => set({selectedMediaType: mediaType}),
   setResizePercent: percent => set({resizePercent: percent}),
   setProcessedImage: image => set({processedImage: image}),
   setIsProcessing: processing => set({isProcessing: processing}),


### PR DESCRIPTION
## 概要
- MainScreen のローカル state だった `selectedMediaType` を `useAppStore` に移動
- `setSelectedMediaType` アクションを store に追加
- リセット処理時も store 経由で media type を `null` に統一

## 備考
- ローカル環境で `eslint` が未インストールのため lint 実行は未実施です

Closes #11
