### PR TITLE
feat: GIF変換にfps/scaleオプションを追加

### DIFF
--- a/app/src/__tests__/FfmpegConverter.test.ts
+++ b/app/src/__tests__/FfmpegConverter.test.ts
@@ -80,10 +80,24 @@ describe('convertImage', () => {
     const result = await convertImage('file:///photos/in.mp4', { outputFormat: 'gif' });
 
     expect(mockExecute).toHaveBeenCalledTimes(2);
+    expect(mockExecute.mock.calls[0][0]).toContain('fps=10');
     expect(mockExecute.mock.calls[0][0]).toContain('palettegen');
     expect(mockExecute.mock.calls[1][0]).toContain('paletteuse');
     expect(mockDeleteAsync).toHaveBeenCalledWith('file:///cache/in_converted_12345_abc.gif.palette.png', { idempotent: true });
     expect(result.outputUri).toMatch(/\.gif$/);
+  });
+
+  it('GIF変換時にfpsとscaleオプションを反映する', async () => {
+    mockGetInfoAsync
+      .mockResolvedValueOnce({ exists: true, size: 1000 })
+      .mockResolvedValueOnce({ exists: true, size: 650 });
+
+    await convertImage('file:///photos/in.mp4', { outputFormat: 'gif', gifFps: 15, gifScale: 50 });
+
+    expect(mockExecute.mock.calls[0][0]).toContain('fps=15');
+    expect(mockExecute.mock.calls[0][0]).toContain('iw*50/100');
+    expect(mockExecute.mock.calls[1][0]).toContain('fps=15');
+    expect(mockExecute.mock.calls[1][0]).toContain('iw*50/100');
   });
 
   it('入力ファイルが存在しない場合はエラー', async () => {

--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -7,6 +7,8 @@ export type ImageFormat = 'jpeg' | 'png' | 'webp' | 'bmp' | 'gif';
 export interface ConvertOptions {
   outputFormat: ImageFormat;
   quality?: number; // compressionRate 0-99 for jpeg/webp (ignored for png)
+  gifFps?: number; // GIF出力フレームレート（デフォルト10）
+  gifScale?: number; // GIFスケール率（1-100, デフォルト100）
 }
 
 export interface FfmpegConvertResult {
@@ -36,7 +38,7 @@ export async function convertImage(
   }
 
   // 前回の一時ファイルをクリーンアップ（#214: アプリ起動時に移動したため削除）
-  const { outputFormat, quality = 0 } = options;
+  const { outputFormat, quality = 0, gifFps = 10, gifScale = 100 } = options;
 
   const inputPath = inputUri.replace('file://', '');
   const fileName = inputPath.split('/').pop() ?? 'image';
@@ -89,12 +91,19 @@ export async function convertImage(
   let rc;
 
   if (outputFormat === 'gif') {
+    const fps = Math.max(1, Math.min(30, Math.round(gifFps)));
+    const scalePercent = Math.max(1, Math.min(100, Math.round(gifScale)));
+    const scaleFilter = scalePercent === 100
+      ? 'scale=iw:ih:flags=lanczos'
+      : `scale=trunc(iw*${scalePercent}/100/2)*2:trunc(ih*${scalePercent}/100/2)*2:flags=lanczos`;
+    const paletteFilter = `fps=${fps},${scaleFilter},palettegen`;
+    const renderFilter = `fps=${fps},${scaleFilter} [x]; [x][1:v] paletteuse`;
     // GIF はパレット生成の2パス方式でアニメーションを保持する
     const palettePath = `${outputPath}.palette.png`;
     const pass1 = [
       '-y',
       '-i', `"${inputPath}"`,
-      '-vf', '"fps=10,palettegen"',
+      '-vf', `"${paletteFilter}"`,
       `"${palettePath}"`,
     ].join(' ');
 
@@ -111,7 +120,7 @@ export async function convertImage(
         '-y',
         '-i', `"${inputPath}"`,
         '-i', `"${palettePath}"`,
-        '-lavfi', '"fps=10 [x]; [x][1:v] paletteuse"',
+        '-lavfi', `"${renderFilter}"`,
         `"${outputPath}"`,
       ].join(' ');
 


### PR DESCRIPTION
## 概要
- `ConvertOptions` に `gifFps` / `gifScale` を追加
- GIF 2パス変換のフィルタをオプション化（デフォルト: fps=10, scale=100%）
- 範囲外入力をクランプ（fps: 1-30, scale: 1-100）
- 単体テストを追加

Fixes #21
