### PR TITLE
feat: 動画圧縮リトライのビットレート再計算を改善

### DIFF
--- a/app/src/__tests__/FfmpegCompressor.test.ts
+++ b/app/src/__tests__/FfmpegCompressor.test.ts
@@ -260,6 +260,27 @@ describe('compressForDiscord (video)', () => {
     expect(result.outputBytes).toBeLessThanOrEqual(target);
   });
 
+  it('出力サイズ比率に応じてリトライビットレートを再計算する', async () => {
+    const target = 10 * 1024 * 1024;
+    mockProbeExecute.mockResolvedValue({
+      getMediaInformation: jest.fn().mockResolvedValue({
+        getDuration: jest.fn().mockReturnValue('30'),
+      }),
+    });
+
+    mockGetInfoAsync
+      .mockResolvedValueOnce({ exists: true, size: 50 * 1024 * 1024 })
+      .mockResolvedValueOnce({ exists: true })
+      .mockResolvedValueOnce({ exists: true, size: 20 * 1024 * 1024 })
+      .mockResolvedValueOnce({ exists: true, size: 18 * 1024 * 1024 })
+      .mockResolvedValueOnce({ exists: true, size: 9 * 1024 * 1024 });
+
+    await compressToTargetSize('file:///videos/clip.mp4', target);
+
+    const executed = mockExecute.mock.calls.map(c => c[0] as string).join('\n');
+    expect(executed).toContain('-b:v 1253k');
+  });
+
   it('throws when input does not exist', async () => {
     mockGetInfoAsync.mockResolvedValueOnce({ exists: false }); // 1. input
     await expect(compressForDiscord('file:///videos/clip.mp4')).rejects.toThrow('入力ファイルが存在しません');

--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -311,7 +311,8 @@ async function compressVideoToTarget(
   let retryBitrate = videoBitrateKbps;
   let scaleFactor = 1.0;
   for (let attempt = 0; attempt < 10 && outputBytes > targetBytes; attempt++) {
-    retryBitrate = Math.floor(retryBitrate * 0.80);
+    const actualRatio = targetBytes / outputBytes;
+    retryBitrate = Math.floor(retryBitrate * actualRatio * 0.92);
     if (retryBitrate < 50) break;
 
     // 3回リトライしてもダメな場合は段階的にリサイズ (0.75x) を適用


### PR DESCRIPTION
## 概要
- `compressVideoToTarget` のリトライ時ビットレートを固定80%削減から、実出力サイズ比率ベースへ変更
- 計算式: `retryBitrate = floor(retryBitrate * (targetBytes/outputBytes) * 0.92)`
- 過圧縮を抑えつつ目標サイズへの収束性を改善
- 再計算ロジックのテストを追加

Fixes #20
