### PR TITLE
feat: Zustand設定を永続化（persist middleware）

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "0.0.1",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-navigation/native": "^7.1.11",
         "@react-navigation/native-stack": "^7.3.16",
         "expo": "^55.0.2",
@@ -3880,6 +3881,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -10313,6 +10326,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -12257,6 +12279,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@react-navigation/native": "^7.1.11",
     "@react-navigation/native-stack": "^7.3.16",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "expo": "^55.0.2",
     "expo-clipboard": "~7.1.4",
     "expo-dev-client": "^55.0.9",

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -1,4 +1,6 @@
 import {create} from 'zustand';
+import {persist, createJSONStorage} from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ImageFormat } from '../domain/convertImage';
 
 export type VideoFormat = 'mp4' | 'mov' | 'mkv' | 'webm';
@@ -43,38 +45,59 @@ interface AppState {
   setTargetSizeUnit: (unit: SizeUnit) => void;
 }
 
-export const useAppStore = create<AppState>(set => ({
-  selectedImage: null,
-  selectedMediaType: null,
-  resizePercent: 100,
-  processedImage: null,
-  isProcessing: false,
-  outputFormat: 'jpeg',
-  compressionRate: 0,
-  gabigabiLevel: null,
-  videoOutputFormat: 'mp4',
-  shrinkExpandEnabled: false,
-  shrinkExpandRate: 50,
-  multiCompressEnabled: false,
-  multiCompressCount: 3,
-  convertMethod: 'parameters',
-  targetSizeValue: '10',
-  targetSizeUnit: 'MB',
-  
-  setSelectedImage: image => set({selectedImage: image}),
-  setSelectedMediaType: mediaType => set({selectedMediaType: mediaType}),
-  setResizePercent: percent => set({resizePercent: percent}),
-  setProcessedImage: image => set({processedImage: image}),
-  setIsProcessing: processing => set({isProcessing: processing}),
-  setOutputFormat: format => set({outputFormat: format}),
-  setCompressionRate: rate => set({compressionRate: rate}),
-  setGabigabiLevel: level => set({gabigabiLevel: level}),
-  setVideoOutputFormat: format => set({videoOutputFormat: format}),
-  setShrinkExpandEnabled: enabled => set({shrinkExpandEnabled: enabled}),
-  setShrinkExpandRate: rate => set({shrinkExpandRate: rate}),
-  setMultiCompressEnabled: enabled => set({multiCompressEnabled: enabled}),
-  setMultiCompressCount: count => set({multiCompressCount: count}),
-  setConvertMethod: method => set({convertMethod: method}),
-  setTargetSizeValue: value => set({targetSizeValue: value}),
-  setTargetSizeUnit: unit => set({targetSizeUnit: unit}),
-}));
+export const useAppStore = create<AppState>()(
+  persist(
+    set => ({
+      selectedImage: null,
+      selectedMediaType: null,
+      resizePercent: 100,
+      processedImage: null,
+      isProcessing: false,
+      outputFormat: 'jpeg',
+      compressionRate: 0,
+      gabigabiLevel: null,
+      videoOutputFormat: 'mp4',
+      shrinkExpandEnabled: false,
+      shrinkExpandRate: 50,
+      multiCompressEnabled: false,
+      multiCompressCount: 3,
+      convertMethod: 'parameters',
+      targetSizeValue: '10',
+      targetSizeUnit: 'MB',
+
+      setSelectedImage: image => set({selectedImage: image}),
+      setSelectedMediaType: mediaType => set({selectedMediaType: mediaType}),
+      setResizePercent: percent => set({resizePercent: percent}),
+      setProcessedImage: image => set({processedImage: image}),
+      setIsProcessing: processing => set({isProcessing: processing}),
+      setOutputFormat: format => set({outputFormat: format}),
+      setCompressionRate: rate => set({compressionRate: rate}),
+      setGabigabiLevel: level => set({gabigabiLevel: level}),
+      setVideoOutputFormat: format => set({videoOutputFormat: format}),
+      setShrinkExpandEnabled: enabled => set({shrinkExpandEnabled: enabled}),
+      setShrinkExpandRate: rate => set({shrinkExpandRate: rate}),
+      setMultiCompressEnabled: enabled => set({multiCompressEnabled: enabled}),
+      setMultiCompressCount: count => set({multiCompressCount: count}),
+      setConvertMethod: method => set({convertMethod: method}),
+      setTargetSizeValue: value => set({targetSizeValue: value}),
+      setTargetSizeUnit: unit => set({targetSizeUnit: unit}),
+    }),
+    {
+      name: 'gabigabi-app-settings',
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: state => ({
+        outputFormat: state.outputFormat,
+        compressionRate: state.compressionRate,
+        gabigabiLevel: state.gabigabiLevel,
+        videoOutputFormat: state.videoOutputFormat,
+        shrinkExpandEnabled: state.shrinkExpandEnabled,
+        shrinkExpandRate: state.shrinkExpandRate,
+        multiCompressEnabled: state.multiCompressEnabled,
+        multiCompressCount: state.multiCompressCount,
+        convertMethod: state.convertMethod,
+        targetSizeValue: state.targetSizeValue,
+        targetSizeUnit: state.targetSizeUnit,
+      }),
+    },
+  ),
+);

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1756,6 +1756,13 @@
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
+"@react-native-async-storage/async-storage@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz"
+  integrity sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-community/cli-clean@19.0.0":
   version "19.0.0"
   resolved "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-19.0.0.tgz"
@@ -4879,6 +4886,11 @@ is-path-inside@^3.0.3:
   resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
 is-regex@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz"
@@ -5702,6 +5714,13 @@ memoize-one@^5.0.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz"
   integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## 概要
- Zustandストアに `persist` middleware を導入
- AsyncStorage を保存先に設定し、設定系の状態のみ永続化
- 変換対象ファイルや処理状態などの一時状態は永続化対象外

## 変更点
- `@react-native-async-storage/async-storage` を依存に追加
- `useAppStore` を `persist(...)` でラップ
- `partialize` で保持するキーを限定

Fixes #12
