### PR TITLE
refactor: getFileSizeBytesの型キャストを型ガードに置換

### DIFF
--- a/app/src/data/ffmpeg/ffmpegUtils.ts
+++ b/app/src/data/ffmpeg/ffmpegUtils.ts
@@ -87,7 +87,11 @@ export async function cleanupCachedTempFiles(): Promise<void> {
  * expo-file-system の getInfoAsync 結果からファイルサイズを安全に取得する。
  * ファイルが存在しない場合や size プロパティがない場合は 0 を返す。
  */
+function hasNumericSize(info: FileSystem.FileInfo): info is FileSystem.FileInfo & { size: number } {
+  return 'size' in info && typeof info.size === 'number';
+}
+
 export function getFileSizeBytes(info: FileSystem.FileInfo): number {
   if (!info.exists) return 0;
-  return (info as FileSystem.FileInfo & { size: number }).size ?? 0;
+  return hasNumericSize(info) ? info.size : 0;
 }


### PR DESCRIPTION
## 概要
- `getFileSizeBytes` の `as` キャストを廃止
- `size` プロパティ存在確認用の型ガード関数を追加

## 期待効果
- `expo-file-system` の `FileInfo` 取得時に、型安全に `size` を扱える
- 型キャスト依存を減らし、リファクタ容易性を改善

Fixes #10
