### PR TITLE
refactor: FFmpegコマンド構築処理をヘルパーへ集約

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -1,6 +1,6 @@
 import { FFmpegKit, FFprobeKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getPasslogConfig, getFileSizeBytes } from './ffmpegUtils';
+import { buildFfmpegCommand, generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getPasslogConfig, getFileSizeBytes } from './ffmpegUtils';
 import { DISCORD_MAX_BYTES } from '../../constants/limits';
 
 export interface CompressResult {
@@ -83,14 +83,14 @@ async function compressImageToTarget(
   // バイナリサーチで targetBytes 以下に収まる最高品質を探す
   while (lo <= hi) {
     const mid = Math.floor((lo + hi) / 2);
-    const cmd = [
+    const cmd = buildFfmpegCommand([
       '-y',
       '-i', `"${inputPath}"`,
       '-q:v', String(mid),
       '-update', '1',
       '-frames:v', '1',
       `"${outputPath}"`,
-    ].join(' ');
+    ]);
 
     const session = await FFmpegKit.execute(cmd);
     const rc = await session.getReturnCode();
@@ -112,7 +112,7 @@ async function compressImageToTarget(
 
   if (bestBytes === 0) {
     // 最低品質でも超えてしまう場合はスケールダウンも加える
-    const cmd = [
+    const cmd = buildFfmpegCommand([
       '-y',
       '-i', `"${inputPath}"`,
       '-vf', '"scale=iw*0.5:ih*0.5"',
@@ -120,7 +120,7 @@ async function compressImageToTarget(
       '-update', '1',
       '-frames:v', '1',
       `"${outputPath}"`,
-    ].join(' ');
+    ]);
     const session = await FFmpegKit.execute(cmd);
     const rc = await session.getReturnCode();
     if (!ReturnCode.isSuccess(rc)) {
@@ -226,7 +226,7 @@ async function compressVideoToTarget(
   const preset = (vcodec === 'libx264') ? ['-preset', 'superfast'] : [];
 
   // 1パス目: CRFモードで高速圧縮を試行 (CRF=28をデフォルトとする)
-  const crfCmd = [
+  const crfCmd = buildFfmpegCommand([
     '-y',
     '-i', `"${inputPath}"`,
     '-c:v', vcodec,
@@ -235,7 +235,7 @@ async function compressVideoToTarget(
     '-c:a', acodec,
     '-b:a', '64k',
     `"${outputPath}"`,
-  ].join(' ');
+  ]);
 
   let useTwoPass = true;
   try {
@@ -254,7 +254,7 @@ async function compressVideoToTarget(
 
   if (useTwoPass) {
     // 2パスエンコードで精度の高いビットレート制御
-    const pass1Cmd = [
+    const pass1Cmd = buildFfmpegCommand([
       '-y',
       '-i', `"${inputPath}"`,
       '-c:v', vcodec,
@@ -264,9 +264,9 @@ async function compressVideoToTarget(
       '-passlogfile', `"${passlogFilesystemPath}"`,
       '-an',
       '-f', isWebm ? 'webm' : 'null', isWebm ? '/dev/null' : '/dev/null',
-    ].join(' ');
+    ]);
 
-    const pass2Cmd = [
+    const pass2Cmd = buildFfmpegCommand([
       '-y',
       '-i', `"${inputPath}"`,
       '-c:v', vcodec,
@@ -277,7 +277,7 @@ async function compressVideoToTarget(
       '-c:a', acodec,
       '-b:a', '64k',
       `"${outputPath}"`,
-    ].join(' ');
+    ]);
 
     try {
       const pass1Session = await FFmpegKit.execute(pass1Cmd);
@@ -327,7 +327,7 @@ async function compressVideoToTarget(
     const retryOutputPath = retryOutputUri.replace('file://', '');
     const { uri: retryPasslogUri, path: retryPasslogPath } = getPasslogConfig(stem, retrySuffix);
 
-    const retry1Cmd = [
+    const retry1Cmd = buildFfmpegCommand([
       '-y', '-i', `"${inputPath}"`,
       '-c:v', vcodec,
       ...preset,
@@ -335,8 +335,8 @@ async function compressVideoToTarget(
       '-b:v', `${retryBitrate}k`,
       '-pass', '1', '-passlogfile', `"${retryPasslogPath}"`,
       '-an', '-f', isWebm ? 'webm' : 'null', isWebm ? '/dev/null' : '/dev/null',
-    ].join(' ');
-    const retry2Cmd = [
+    ]);
+    const retry2Cmd = buildFfmpegCommand([
       '-y', '-i', `"${inputPath}"`,
       '-c:v', vcodec,
       ...preset,
@@ -345,7 +345,7 @@ async function compressVideoToTarget(
       '-pass', '2', '-passlogfile', `"${retryPasslogPath}"`,
       '-c:a', acodec, '-b:a', '64k',
       `"${retryOutputPath}"`,
-    ].join(' ');
+    ]);
 
     const r1 = await FFmpegKit.execute(retry1Cmd);
     if (!ReturnCode.isSuccess(await r1.getReturnCode())) {

--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -1,6 +1,6 @@
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
-import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getFileSizeBytes } from './ffmpegUtils';
+import { buildFfmpegCommand, generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getFileSizeBytes } from './ffmpegUtils';
 
 export type ImageFormat = 'jpeg' | 'png' | 'webp' | 'bmp' | 'gif';
 
@@ -100,12 +100,12 @@ export async function convertImage(
     const renderFilter = `fps=${fps},${scaleFilter} [x]; [x][1:v] paletteuse`;
     // GIF はパレット生成の2パス方式でアニメーションを保持する
     const palettePath = `${outputPath}.palette.png`;
-    const pass1 = [
+    const pass1 = buildFfmpegCommand([
       '-y',
       '-i', `"${inputPath}"`,
       '-vf', `"${paletteFilter}"`,
       `"${palettePath}"`,
-    ].join(' ');
+    ]);
 
     try {
       const pass1Session = await FFmpegKit.execute(pass1);
@@ -116,13 +116,13 @@ export async function convertImage(
         throw new Error(`GIF パレット生成に失敗しました: ${logs}`);
       }
 
-      const pass2 = [
+      const pass2 = buildFfmpegCommand([
         '-y',
         '-i', `"${inputPath}"`,
         '-i', `"${palettePath}"`,
         '-lavfi', `"${renderFilter}"`,
         `"${outputPath}"`,
-      ].join(' ');
+      ]);
 
       session = await FFmpegKit.execute(pass2);
       rc = await session.getReturnCode();
@@ -131,14 +131,14 @@ export async function convertImage(
       await FileSystem.deleteAsync(`file://${palettePath}`, { idempotent: true });
     }
   } else {
-    const cmd = [
+    const cmd = buildFfmpegCommand([
       '-y',
       '-i', `"${inputPath}"`,
       qualityArgs,
       '-update', '1',
       '-frames:v', '1',
       `"${outputPath}"`,
-    ].join(' ');
+    ]);
 
     session = await FFmpegKit.execute(cmd);
     rc = await session.getReturnCode();

--- a/app/src/data/ffmpeg/ffmpegUtils.ts
+++ b/app/src/data/ffmpeg/ffmpegUtils.ts
@@ -95,3 +95,15 @@ export function getFileSizeBytes(info: FileSystem.FileInfo): number {
   if (!info.exists) return 0;
   return hasNumericSize(info) ? info.size : 0;
 }
+
+
+/**
+ * FFmpeg コマンド配列を安全に連結する。
+ * null/undefined/空文字は除外して 1 つの文字列コマンドを返す。
+ */
+export function buildFfmpegCommand(parts: Array<string | number | null | undefined>): string {
+  return parts
+    .filter((part): part is string | number => part !== null && part !== undefined && String(part).trim() !== '')
+    .map(part => String(part))
+    .join(' ');
+}


### PR DESCRIPTION
## 概要
- `buildFfmpegCommand` を `ffmpegUtils.ts` に追加
- Converter/Compressor のコマンド文字列組み立てをヘルパーへ統一
- null/undefined/空文字トークンの除外を共通化

## 補足
- ローカルで `npm test` を試行したが、worktree 環境で `jest: command not found` のため実行不可

Fixes #3
