### PR TITLE
fix: ImagePickerのメディアタイプ選択を動的化

### DIFF
--- a/app/src/components/ImagePicker.tsx
+++ b/app/src/components/ImagePicker.tsx
@@ -8,6 +8,12 @@ interface ImagePickerProps {
   selectedMediaType?: 'image' | 'video';
 }
 
+const resolvePickerMediaTypes = (selectedMediaType?: 'image' | 'video') => {
+  if (selectedMediaType === 'video') return ['videos'] as const;
+  if (selectedMediaType === 'image') return ['images'] as const;
+  return ['images', 'videos'] as const;
+};
+
 const ACCENT = '#ff4e50';
 const CARD_BG = '#1a1a1a';
 const BORDER = '#2a2a2a';
@@ -25,7 +31,7 @@ const ImagePicker: React.FC<ImagePickerProps> = ({
       return;
     }
     const result = await ExpoImagePicker.launchImageLibraryAsync({
-      mediaTypes: ['images', 'videos'],
+      mediaTypes: resolvePickerMediaTypes(selectedMediaType),
       allowsEditing: false,
       quality: 1,
     });

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -400,7 +400,7 @@ const MainScreen = () => {
       return;
     }
     const result = await ExpoImagePicker.launchImageLibraryAsync({
-      mediaTypes: ['images', 'videos'],
+      mediaTypes: resolvePickerMediaTypes(selectedMediaType),
       allowsEditing: false,
       quality: 1,
     });


### PR DESCRIPTION
## 概要\n-  に応じて picker の  を切り替えるよう変更\n  - image選択中: images のみ\n  - video選択中: videos のみ\n  - 未選択時: images/videos 両方\n- MainScreen / ImagePicker の双方で同一挙動に統一\n\n## 関連\n- Closes #9\n\n## 備考\n- ローカル test 実行は  のため未実施