### PR TITLE
fix: 動画ガビガビ化に圧縮率スライダーを適用

### DIFF
--- a/app/src/__tests__/FfmpegProcessor.test.ts
+++ b/app/src/__tests__/FfmpegProcessor.test.ts
@@ -113,4 +113,22 @@ describe('processVideoWithFfmpeg', () => {
     expect(cmd).toContain('-b:v 0');
     expect(cmd).toContain('-crf 50');
   });
+
+  it('compressionRate指定時はmp4のCRFを線形マッピングする', async () => {
+    mockGetInfoAsync
+      .mockResolvedValueOnce({ exists: true, size: 1000 })
+      .mockResolvedValueOnce({ exists: true, size: 700 });
+
+    await processVideoWithFfmpeg('file:///in.mp4', 100, 0, 'mp4', 99);
+    expect(lastCmd()).toContain('-crf 51');
+  });
+
+  it('compressionRate指定時はwebmのCRFを線形マッピングする', async () => {
+    mockGetInfoAsync
+      .mockResolvedValueOnce({ exists: true, size: 1000 })
+      .mockResolvedValueOnce({ exists: true, size: 700 });
+
+    await processVideoWithFfmpeg('file:///in.webm', 100, 0, 'webm', 0);
+    expect(lastCmd()).toContain('-crf 33');
+  });
 });

--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -81,12 +81,16 @@ export async function processVideoWithFfmpeg(
   scalePct: number,
   gabigabiLevel: number = 2,
   outputFormat: VideoFormat = 'mp4',
+  compressionRate?: number,
 ): Promise<FfmpegProcessResult> {
   if (scalePct <= 0 || scalePct > 100) {
     throw new Error('scalePct must be within (0, 100]');
   }
   if (gabigabiLevel < 0 || gabigabiLevel > 5) {
     throw new Error('gabigabiLevel must be 0-5');
+  }
+  if (compressionRate !== undefined && (compressionRate < 0 || compressionRate > 99)) {
+    throw new Error('compressionRate must be 0-99');
   }
 
   const inputInfo = await FileSystem.getInfoAsync(inputUri, { size: true });
@@ -109,9 +113,21 @@ export async function processVideoWithFfmpeg(
 
   if (__DEV__) console.log('[FFmpeg] video outputPath:', outputPath);
 
-  const crf = outputFormat === 'webm'
-    ? (GABIGABI_CRF_VP9[gabigabiLevel] ?? 50)
-    : (GABIGABI_CRF_H264[gabigabiLevel] ?? 40);
+  const crf = (() => {
+    if (compressionRate === undefined) {
+      return outputFormat === 'webm'
+        ? (GABIGABI_CRF_VP9[gabigabiLevel] ?? 50)
+        : (GABIGABI_CRF_H264[gabigabiLevel] ?? 40);
+    }
+
+    // 圧縮率 0〜99 を CRF 範囲へ線形マッピング
+    if (outputFormat === 'webm') {
+      // VP9: 33〜63
+      return Math.round(33 + (63 - 33) * (compressionRate / 99));
+    }
+    // H.264: 23〜51
+    return Math.round(23 + (51 - 23) * (compressionRate / 99));
+  })();
   const scale = scalePct / 100;
 
   const codecArgs = VIDEO_FORMAT_CODECS[outputFormat] ?? VIDEO_FORMAT_CODECS.mp4;

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -505,7 +505,13 @@ const MainScreen = () => {
 
       if (selectedMediaType === 'video') {
         // 動画のガビガビ化
-        const result = await processVideoWithFfmpeg(selectedImage, resizePercent, gabigabiLevel ?? 0, videoOutputFormat);
+        const result = await processVideoWithFfmpeg(
+          selectedImage,
+          resizePercent,
+          gabigabiLevel ?? 0,
+          videoOutputFormat,
+          compressionRate,
+        );
         resultUri = result.outputUri;
         resultBytes = result.outputBytes;
       } else {
@@ -881,7 +887,7 @@ const MainScreen = () => {
                 </>
               )}
 
-              {selectedMediaType !== 'video' && (outputFormat === 'jpeg' || outputFormat === 'webp') && (
+              {((selectedMediaType !== 'video' && (outputFormat === 'jpeg' || outputFormat === 'webp')) || selectedMediaType === 'video') && (
                 <View style={styles.qualityRow}>
                   <View style={styles.qualityLabelRow}>
                     <Text style={styles.qualityLabel}>圧縮率</Text>
@@ -894,8 +900,8 @@ const MainScreen = () => {
                     step={1}
                     value={compressionRate}
                     onValueChange={(v: number) => handleQualityChange(Math.round(v))}
-                    accessibilityLabel="画像圧縮率スライダー"
-                    accessibilityHint="0%から99%の範囲で圧縮率を変更します"
+                    accessibilityLabel={selectedMediaType === 'video' ? '動画圧縮率スライダー' : '画像圧縮率スライダー'}
+                    accessibilityHint={selectedMediaType === 'video' ? '0%から99%の範囲で動画の圧縮率を変更します' : '0%から99%の範囲で画像の圧縮率を変更します'}
                     minimumTrackTintColor={ACCENT2}
                     maximumTrackTintColor={BORDER}
                     thumbTintColor={ACCENT2}


### PR DESCRIPTION
## 概要
- 動画変換時にも圧縮率スライダー（0-99）を表示
- 圧縮率を動画CRFへ線形マッピングして `processVideoWithFfmpeg` に反映
  - H.264: 23-51
  - VP9(WebM): 33-63
- FfmpegProcessorテストに動画圧縮率マッピングのケースを追加

## 関連
- Fixes #18

## 補足
- ローカル実行環境で app の依存が未導入のため、Jestの実行確認は未実施です。