### PR TITLE
feat: 変換履歴機能のプロトタイプを追加

### DIFF
--- a/app/src/__tests__/conversionHistory.test.ts
+++ b/app/src/__tests__/conversionHistory.test.ts
@@ -1,0 +1,50 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {getConversionHistory, saveConversionHistoryItem} from '../data/history/conversionHistory';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+const mockedAsyncStorage = AsyncStorage as unknown as {
+  getItem: jest.Mock;
+  setItem: jest.Mock;
+};
+
+describe('conversionHistory', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('保存済み履歴を返す', async () => {
+    mockedAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([{id: '1'}]));
+    const rows = await getConversionHistory();
+    expect(rows).toEqual([{id: '1'}]);
+  });
+
+  it('履歴が壊れていたら空配列を返す', async () => {
+    mockedAsyncStorage.getItem.mockResolvedValueOnce('{broken');
+    const rows = await getConversionHistory();
+    expect(rows).toEqual([]);
+  });
+
+  it('新しい履歴を先頭に追加して保存する', async () => {
+    mockedAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([{id: 'old'}]));
+
+    await saveConversionHistoryItem({
+      id: 'new',
+      createdAt: '2026-03-22T00:00:00.000Z',
+      inputPath: 'file:///in.jpg',
+      outputPath: 'file:///out.jpg',
+      inputBytes: 100,
+      outputBytes: 50,
+      mediaType: 'image',
+      params: {action: 'gabigabi'},
+    });
+
+    expect(mockedAsyncStorage.setItem).toHaveBeenCalledWith(
+      'conversion-history-v1',
+      JSON.stringify([{id: 'new', createdAt: '2026-03-22T00:00:00.000Z', inputPath: 'file:///in.jpg', outputPath: 'file:///out.jpg', inputBytes: 100, outputBytes: 50, mediaType: 'image', params: {action: 'gabigabi'}}, {id: 'old'}]),
+    );
+  });
+});

--- a/app/src/data/history/conversionHistory.ts
+++ b/app/src/data/history/conversionHistory.ts
@@ -1,0 +1,46 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {ImageFormat} from '../../domain/convertImage';
+import {VideoFormat} from '../../state/store';
+
+const STORAGE_KEY = 'conversion-history-v1';
+const MAX_ITEMS = 50;
+
+export type ConversionAction = 'gabigabi' | 'convert' | 'targetSize';
+
+export interface ConversionHistoryItem {
+  id: string;
+  createdAt: string;
+  inputPath: string;
+  outputPath: string;
+  inputBytes: number;
+  outputBytes: number;
+  mediaType: 'image' | 'video';
+  params: {
+    action: ConversionAction;
+    outputFormat?: ImageFormat;
+    videoOutputFormat?: VideoFormat;
+    gabigabiLevel?: number | null;
+    resizePercent?: number;
+    compressionRate?: number;
+    targetBytes?: number;
+  };
+}
+
+export async function getConversionHistory(): Promise<ConversionHistoryItem[]> {
+  const raw = await AsyncStorage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as ConversionHistoryItem[];
+  } catch {
+    return [];
+  }
+}
+
+export async function saveConversionHistoryItem(item: ConversionHistoryItem): Promise<void> {
+  const current = await getConversionHistory();
+  const next = [item, ...current].slice(0, MAX_ITEMS);
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+}

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -36,6 +36,7 @@ import {convertImage, formatBytes, ImageFormat} from '../domain/convertImage';
 import {FFmpegKit, FFprobeKit} from 'ffmpeg-kit-react-native';
 import {processVideoWithFfmpeg} from '../data/ffmpeg/FfmpegProcessor';
 import {cleanupCachedTempFiles, getFileSizeBytes} from '../data/ffmpeg/ffmpegUtils';
+import {saveConversionHistoryItem, ConversionAction} from '../data/history/conversionHistory';
 
 const FORMAT_OPTIONS: {label: string; value: ImageFormat}[] = [
   {label: 'JPEG', value: 'jpeg'},
@@ -318,6 +319,34 @@ const MainScreen = () => {
   const [fileInfo, setFileInfo] = useState<{name: string; size: string; width: number; height: number} | null>(null);
   const outputBytesRef = useRef(0);
 
+  const saveHistory = useCallback(async (
+    action: ConversionAction,
+    inputPath: string,
+    outputPath: string,
+    inputBytes: number,
+    outputBytes: number,
+    targetBytes?: number,
+  ) => {
+    await saveConversionHistoryItem({
+      id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      createdAt: new Date().toISOString(),
+      inputPath,
+      outputPath,
+      inputBytes,
+      outputBytes,
+      mediaType: selectedMediaType ?? 'image',
+      params: {
+        action,
+        outputFormat,
+        videoOutputFormat,
+        gabigabiLevel,
+        resizePercent,
+        compressionRate,
+        targetBytes,
+      },
+    });
+  }, [selectedMediaType, outputFormat, videoOutputFormat, gabigabiLevel, resizePercent, compressionRate]);
+
   // #214: アプリ起動時に一度だけ一時ファイルをクリーンアップする（変換開始時からの移動）
   useEffect(() => {
     cleanupCachedTempFiles();
@@ -502,6 +531,10 @@ const MainScreen = () => {
     try {
       let resultUri: string;
       let resultBytes: number;
+      let inputBytes = 0;
+
+      const inputInfo = await FileSystem.getInfoAsync(selectedImage, {size: true});
+      inputBytes = getFileSizeBytes(inputInfo);
 
       if (selectedMediaType === 'video') {
         // 動画のガビガビ化
@@ -509,9 +542,6 @@ const MainScreen = () => {
         resultUri = result.outputUri;
         resultBytes = result.outputBytes;
       } else {
-        const inputInfo = await FileSystem.getInfoAsync(selectedImage, {size: true});
-        const inputBytes = getFileSizeBytes(inputInfo);
-
         // ガビガビレベル0 かつ フォーマット変換が必要な場合はフォーマット変換のみ
       // ガビガビレベル1以上の場合はガビガビ化（リサイズ+品質劣化）
       // 両方の設定を1回の「変換」で適用する
@@ -552,6 +582,7 @@ const MainScreen = () => {
 
       setProcessedImage(resultUri);
       outputBytesRef.current = resultBytes;
+      await saveHistory('gabigabi', selectedImage, resultUri, inputBytes, resultBytes);
     } catch (err) {
       const msg = String(err);
       if (!msg.includes('cancel') && !msg.includes('Cancel')) {
@@ -640,9 +671,12 @@ const MainScreen = () => {
     setIsProcessing(true);
     setProcessingAction('targetSize');
     try {
+      const inputInfo = await FileSystem.getInfoAsync(selectedImage, {size: true});
+      const inputBytes = getFileSizeBytes(inputInfo);
       const result = await compressToTargetSize(selectedImage, targetBytes, videoOutputFormat);
       setProcessedImage(result.outputUri);
       outputBytesRef.current = result.outputBytes;
+      await saveHistory('targetSize', selectedImage, result.outputUri, inputBytes, result.outputBytes, targetBytes);
     } catch (err) {
       const msg = String(err);
       if (!msg.includes('cancel') && !msg.includes('Cancel')) {


### PR DESCRIPTION
## 概要\n- AsyncStorage に変換履歴を保存するユーティリティを追加\n- 変換成功時（通常変換/目標サイズ変換）に履歴を自動保存\n- 履歴ユーティリティのユニットテストを追加\n\n## 補足\n- 保存上限は最新50件\n- 履歴項目には入出力パス、サイズ、変換パラメータを含む\n\nFixes #2