### PR TITLE
feat: ガビガビレベル0を廃止し劣化を強化

### DIFF
--- a/app/src/__tests__/FfmpegProcessor.test.ts
+++ b/app/src/__tests__/FfmpegProcessor.test.ts
@@ -46,13 +46,13 @@ describe('processWithFfmpeg', () => {
     setupSuccess();
   });
 
-  it('gabigabiLevelマッピングを使う（level=3 -> q:v 21）', async () => {
+  it('gabigabiLevelマッピングを使う（level=3 -> q:v 24）', async () => {
     mockGetInfoAsync
       .mockResolvedValueOnce({ exists: true, size: 1000 })
       .mockResolvedValueOnce({ exists: true, size: 800 });
 
     await processWithFfmpeg('file:///in.jpg', 100, 3);
-    expect(lastCmd()).toContain('-q:v 21');
+    expect(lastCmd()).toContain('-q:v 24');
   });
 
   it('shrinkExpandEnabledで縮小→再拡大フィルタを追加する', async () => {
@@ -99,7 +99,7 @@ describe('processVideoWithFfmpeg', () => {
     const cmd = lastCmd();
     expect(cmd).toContain('libx264');
     expect(cmd).toContain('aac');
-    expect(cmd).toContain('-crf 40');
+    expect(cmd).toContain('-crf 43');
   });
 
   it('webmでvp9とb:v 0を使う', async () => {
@@ -111,7 +111,7 @@ describe('processVideoWithFfmpeg', () => {
     const cmd = lastCmd();
     expect(cmd).toContain('libvpx-vp9');
     expect(cmd).toContain('-b:v 0');
-    expect(cmd).toContain('-crf 50');
+    expect(cmd).toContain('-crf 55');
   });
 
   it('compressionRate指定時はmp4のCRFを線形マッピングする', async () => {

--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -16,11 +16,11 @@ export interface FfmpegProcessResult {
  */
 const GABIGABI_QUALITY: Record<number, number> = {
   0: 1,  // 圧縮率 0% → q:v=1（ほぼ劣化なし）
-  1: 8,  // 圧縮率55% → q:v=8
-  2: 13, // 圧縮率70% → q:v=13
-  3: 21, // 圧縮率85% → q:v=21
-  4: 25, // 圧縮率92% → q:v=25
-  5: 30, // 圧縮率99% → q:v=30
+  1: 12, // 圧縮率72% → q:v=12
+  2: 18, // 圧縮率84% → q:v=18
+  3: 24, // 圧縮率94% → q:v=24
+  4: 28, // 圧縮率98% → q:v=28
+  5: 31, // 圧縮率99% → q:v=31（最大劣化）
 };
 
 /**
@@ -37,10 +37,10 @@ const GABIGABI_QUALITY: Record<number, number> = {
  */
 const GABIGABI_CRF_H264: Record<number, number> = {
   0: 23, // ほぼ劣化なし
-  1: 35,
-  2: 40,
-  3: 45,
-  4: 48,
+  1: 38,
+  2: 43,
+  3: 47,
+  4: 50,
   5: 51, // 最低品質
 };
 
@@ -50,10 +50,10 @@ const GABIGABI_CRF_H264: Record<number, number> = {
  */
 const GABIGABI_CRF_VP9: Record<number, number> = {
   0: 33, // ほぼ劣化なし
-  1: 45,
-  2: 50,
-  3: 55,
-  4: 60,
+  1: 50,
+  2: 55,
+  3: 59,
+  4: 62,
   5: 63, // 最低品質
 };
 

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -54,7 +54,6 @@ const VIDEO_FORMAT_OPTIONS: {label: string; value: VideoFormat}[] = [
 ];
 
 const GABIGABI_LEVELS: {label: string; value: number}[] = [
-  {label: '0', value: 0},
   {label: '1', value: 1},
   {label: '2', value: 2},
   {label: '3', value: 3},
@@ -71,12 +70,11 @@ const TEMPLATE_SETTINGS: Record<number, {
   multiCompressEnabled: boolean;
   multiCompressCount: number;
 }> = {
-  0: {resizePercent: 100, compressionRate: 0,  shrinkExpandEnabled: false, shrinkExpandRate: 50, multiCompressEnabled: false, multiCompressCount: 3},
-  1: {resizePercent: 100, compressionRate: 55, shrinkExpandEnabled: false, shrinkExpandRate: 50, multiCompressEnabled: false, multiCompressCount: 3},
-  2: {resizePercent: 75,  compressionRate: 70, shrinkExpandEnabled: false, shrinkExpandRate: 50, multiCompressEnabled: false, multiCompressCount: 3},
-  3: {resizePercent: 25,  compressionRate: 99, shrinkExpandEnabled: false, shrinkExpandRate: 50, multiCompressEnabled: false, multiCompressCount: 3},
-  4: {resizePercent: 25,  compressionRate: 99, shrinkExpandEnabled: true,  shrinkExpandRate: 50, multiCompressEnabled: false, multiCompressCount: 3},
-  5: {resizePercent: 5,   compressionRate: 99, shrinkExpandEnabled: true,  shrinkExpandRate: 50, multiCompressEnabled: true,  multiCompressCount: 3},
+  1: {resizePercent: 90, compressionRate: 72, shrinkExpandEnabled: false, shrinkExpandRate: 50, multiCompressEnabled: false, multiCompressCount: 3},
+  2: {resizePercent: 70, compressionRate: 84, shrinkExpandEnabled: false, shrinkExpandRate: 50, multiCompressEnabled: false, multiCompressCount: 3},
+  3: {resizePercent: 45, compressionRate: 94, shrinkExpandEnabled: false, shrinkExpandRate: 50, multiCompressEnabled: true,  multiCompressCount: 2},
+  4: {resizePercent: 30, compressionRate: 98, shrinkExpandEnabled: true,  shrinkExpandRate: 45, multiCompressEnabled: true,  multiCompressCount: 3},
+  5: {resizePercent: 15, compressionRate: 99, shrinkExpandEnabled: true,  shrinkExpandRate: 35, multiCompressEnabled: true,  multiCompressCount: 4},
 };
 
 const TARGET_SIZE_TEMPLATES: {label: string; value: string; unit: SizeUnit}[] = [
@@ -492,7 +490,7 @@ const MainScreen = () => {
 
   const handleTemplateSelect = useCallback(
     (level: number) => {
-      const settings = TEMPLATE_SETTINGS[level];
+      const settings = TEMPLATE_SETTINGS[level] ?? TEMPLATE_SETTINGS[1];
       setGabigabiLevel(level);
       setResizePercent(settings.resizePercent);
       setCompressionRate(settings.compressionRate);
@@ -541,7 +539,7 @@ const MainScreen = () => {
         const result = await processVideoWithFfmpeg(
           selectedImage,
           resizePercent,
-          gabigabiLevel ?? 0,
+          gabigabiLevel ?? 1,
           videoOutputFormat,
           compressionRate,
         );


### PR DESCRIPTION
## 概要
- ガビガビレベル0をUI選択肢から削除
- レベル1〜5の劣化パラメータを強化（画像/動画）
- 関連テストを更新

## 補足
- 既存PR #53 が DIRTY でマージ不能だったため、master最新に取り込み直したPRです。

Closes #5