### PR TITLE
fix: 履歴保存時のaction種別を正確に記録

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -529,6 +529,7 @@ const MainScreen = () => {
     try {
       let resultUri: string;
       let resultBytes: number;
+      let historyAction: ConversionAction = 'gabigabi';
       let inputBytes = 0;
 
       const inputInfo = await FileSystem.getInfoAsync(selectedImage, {size: true});
@@ -551,6 +552,7 @@ const MainScreen = () => {
         // 両方の設定を1回の「変換」で適用する
 
         if (gabigabiLevel === null) {
+          historyAction = 'convert';
           // ガビガビなし → フォーマット変換 + リサイズのみ
           if (resizePercent === 100 && outputFormat === 'jpeg') {
             // 何も変更なし
@@ -560,18 +562,18 @@ const MainScreen = () => {
           if (resizePercent < 100) {
             // リサイズのみ実行（手動調整）
             const result = await resizeImage(selectedImage, resizePercent, 0);
-          resultUri = result.outputUri;
-          resultBytes = result.outputBytes;
+            resultUri = result.outputUri;
+            resultBytes = result.outputBytes;
+          } else {
+            // フォーマット変換のみ
+            const result = await convertImage(selectedImage, {
+              outputFormat,
+              quality: compressionRate,
+            });
+            resultUri = result.outputUri;
+            resultBytes = result.outputBytes;
+          }
         } else {
-          // フォーマット変換のみ
-          const result = await convertImage(selectedImage, {
-            outputFormat,
-            quality: compressionRate,
-          });
-          resultUri = result.outputUri;
-          resultBytes = result.outputBytes;
-        }
-      } else {
         // ガビガビ化（リサイズ + 品質劣化）
         const result = await resizeImage(selectedImage, resizePercent, gabigabiLevel!, {
           shrinkExpandEnabled,
@@ -586,7 +588,7 @@ const MainScreen = () => {
 
       setProcessedImage(resultUri);
       outputBytesRef.current = resultBytes;
-      await saveHistory('gabigabi', selectedImage, resultUri, inputBytes, resultBytes);
+      await saveHistory(historyAction, selectedImage, resultUri, inputBytes, resultBytes);
     } catch (err) {
       const msg = String(err);
       if (!msg.includes('cancel') && !msg.includes('Cancel')) {


### PR DESCRIPTION
## 概要
- 変換時に `gabigabiLevel === null`（ガビガビ未使用）の場合、履歴の `params.action` を `convert` として保存するよう修正
- これまで `gabigabi` 固定で保存されていたため、履歴分析時に通常変換とガビガビ変換を区別できない問題を解消

## 補足
- テスト実行を試みたが、環境に `jest` がなく未実行（`sh: jest: command not found`）

Closes #2
