### PR TITLE
feat: issue #16 i18n基盤と主要UI文言の英語対応

### DIFF
--- a/app/src/components/ErrorModal.tsx
+++ b/app/src/components/ErrorModal.tsx
@@ -8,6 +8,7 @@ import {
   StyleSheet,
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
+import {t} from '../i18n';
 
 interface ErrorModalProps {
   visible: boolean;
@@ -25,7 +26,7 @@ const BORDER = '#2a2a2a';
 
 const ErrorModal: React.FC<ErrorModalProps> = ({
   visible,
-  title = 'エラー',
+  title = t('error'),
   message,
   onClose,
 }) => {
@@ -67,7 +68,7 @@ const ErrorModal: React.FC<ErrorModalProps> = ({
               onPress={handleCopy}
               activeOpacity={0.8}>
               <Text style={styles.copyButtonText}>
-                {copied ? 'コピー済み ✓' : 'コピー'}
+                {copied ? t('copied') : t('copy')}
               </Text>
             </TouchableOpacity>
 
@@ -75,7 +76,7 @@ const ErrorModal: React.FC<ErrorModalProps> = ({
               style={styles.closeButton}
               onPress={onClose}
               activeOpacity={0.8}>
-              <Text style={styles.closeButtonText}>閉じる</Text>
+              <Text style={styles.closeButtonText}>{t('close')}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/app/src/components/ImagePicker.tsx
+++ b/app/src/components/ImagePicker.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {View, TouchableOpacity, Text, StyleSheet, Alert} from 'react-native';
 import * as ExpoImagePicker from 'expo-image-picker';
+import {t} from '../i18n';
 
 interface ImagePickerProps {
   onImageSelect: (imageUri: string, mediaType: 'image' | 'video') => void;
@@ -27,7 +28,7 @@ const ImagePicker: React.FC<ImagePickerProps> = ({
   const handlePress = async () => {
     const { status } = await ExpoImagePicker.requestMediaLibraryPermissionsAsync();
     if (status !== 'granted') {
-      Alert.alert('権限が必要', 'ギャラリーへのアクセスを許可してください');
+      Alert.alert(t('permissionRequired'), t('galleryPermissionMessage'));
       return;
     }
     const result = await ExpoImagePicker.launchImageLibraryAsync({
@@ -55,12 +56,12 @@ const ImagePicker: React.FC<ImagePickerProps> = ({
       <Text style={styles.buttonText}>
         {selectedImage
           ? isVideo
-            ? '動画を変更する'
-            : '画像を変更する'
-          : '画像 / 動画を選択する'}
+            ? t('changeVideo')
+            : t('changeImage')
+          : t('pickImageOrVideo')}
       </Text>
       {!selectedImage && (
-        <Text style={styles.hint}>タップしてギャラリーを開く</Text>
+        <Text style={styles.hint}>{t('tapToOpenGallery')}</Text>
       )}
     </TouchableOpacity>
   );

--- a/app/src/components/ResizeSlider.tsx
+++ b/app/src/components/ResizeSlider.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useEffect} from 'react';
 import {View, Text, TextInput, StyleSheet, TouchableOpacity} from 'react-native';
 import CustomSlider from './CustomSlider';
+import {t} from '../i18n';
 
 interface ResizeSliderProps {
   value: number;
@@ -60,14 +61,14 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
           style={[styles.tab, activeTab === 'percent' && styles.tabActive]}
           onPress={() => setActiveTab('percent')}
           activeOpacity={0.7}>
-          <Text style={[styles.tabText, activeTab === 'percent' && styles.tabTextActive]}>% 指定</Text>
+          <Text style={[styles.tabText, activeTab === 'percent' && styles.tabTextActive]}>{t('resizePercentTab')}</Text>
         </TouchableOpacity>
         {hasOriginal && (
           <TouchableOpacity
             style={[styles.tab, activeTab === 'resolution' && styles.tabActive]}
             onPress={() => setActiveTab('resolution')}
             activeOpacity={0.7}>
-            <Text style={[styles.tabText, activeTab === 'resolution' && styles.tabTextActive]}>解像度指定</Text>
+            <Text style={[styles.tabText, activeTab === 'resolution' && styles.tabTextActive]}>{t('resizeResolutionTab')}</Text>
           </TouchableOpacity>
         )}
       </View>
@@ -76,7 +77,7 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
       {activeTab === 'percent' && (
         <View style={styles.tabContent}>
           <View style={styles.percentHeader}>
-            <Text style={styles.label}>リサイズ倍率</Text>
+            <Text style={styles.label}>{t('resizeScale')}</Text>
             <Text style={styles.valueDisplay}>
               <Text style={styles.valueNumber}>{Math.round(value)}</Text>
               <Text style={styles.valueUnit}>%</Text>
@@ -84,8 +85,8 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
           </View>
           <CustomSlider
             style={styles.slider}
-            accessibilityLabel="リサイズ倍率スライダー"
-            accessibilityHint="1%から100%の範囲で画像サイズを変更します"
+            accessibilityLabel={t('resizeScaleSliderLabel')}
+            accessibilityHint={t('resizeScaleSliderHint')}
             minimumValue={1}
             maximumValue={100}
             step={1}
@@ -108,7 +109,7 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
         <View style={styles.tabContent}>
           <View style={styles.directRow}>
             <View style={styles.directInput}>
-              <Text style={styles.directLabel}>幅</Text>
+              <Text style={styles.directLabel}>{t('width')}</Text>
               <TextInput
                 style={styles.input}
                 keyboardType="number-pad"
@@ -119,7 +120,7 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
             </View>
             <Text style={styles.directX}>×</Text>
             <View style={styles.directInput}>
-              <Text style={styles.directLabel}>高さ</Text>
+              <Text style={styles.directLabel}>{t('height')}</Text>
               <TextInput
                 style={styles.input}
                 keyboardType="number-pad"

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -1,0 +1,29 @@
+const locale = Intl.DateTimeFormat().resolvedOptions().locale?.toLowerCase() ?? 'ja';
+const isJapanese = locale.startsWith('ja');
+
+type Dict = Record<string, {ja: string; en: string}>;
+
+const DICT: Dict = {
+  error: {ja: 'エラー', en: 'Error'},
+  copy: {ja: 'コピー', en: 'Copy'},
+  copied: {ja: 'コピー済み ✓', en: 'Copied ✓'},
+  close: {ja: '閉じる', en: 'Close'},
+  permissionRequired: {ja: '権限が必要', en: 'Permission required'},
+  galleryPermissionMessage: {ja: 'ギャラリーへのアクセスを許可してください', en: 'Please allow gallery access.'},
+  pickImageOrVideo: {ja: '画像 / 動画を選択する', en: 'Select image / video'},
+  changeImage: {ja: '画像を変更する', en: 'Change image'},
+  changeVideo: {ja: '動画を変更する', en: 'Change video'},
+  tapToOpenGallery: {ja: 'タップしてギャラリーを開く', en: 'Tap to open gallery'},
+  resizePercentTab: {ja: '% 指定', en: '%'},
+  resizeResolutionTab: {ja: '解像度指定', en: 'Resolution'},
+  resizeScale: {ja: 'リサイズ倍率', en: 'Resize scale'},
+  resizeScaleSliderLabel: {ja: 'リサイズ倍率スライダー', en: 'Resize scale slider'},
+  resizeScaleSliderHint: {ja: '1%から100%の範囲で画像サイズを変更します', en: 'Adjust image size from 1% to 100%.'},
+  width: {ja: '幅', en: 'Width'},
+  height: {ja: '高さ', en: 'Height'},
+};
+
+export const t = (key: keyof typeof DICT): string => {
+  const item = DICT[key];
+  return isJapanese ? item.ja : item.en;
+};

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -37,6 +37,7 @@ import {FFmpegKit, FFprobeKit} from 'ffmpeg-kit-react-native';
 import {processVideoWithFfmpeg} from '../data/ffmpeg/FfmpegProcessor';
 import {cleanupCachedTempFiles, getFileSizeBytes} from '../data/ffmpeg/ffmpegUtils';
 import {saveConversionHistoryItem, ConversionAction} from '../data/history/conversionHistory';
+import {t} from '../i18n';
 
 const FORMAT_OPTIONS: {label: string; value: ImageFormat}[] = [
   {label: 'JPEG', value: 'jpeg'},
@@ -283,7 +284,7 @@ const MainScreen = () => {
 
   const [errorModal, setErrorModal] = useState<{visible: boolean; title: string; message: string}>({
     visible: false,
-    title: 'エラー',
+    title: t('error'),
     message: '',
   });
 
@@ -423,7 +424,7 @@ const MainScreen = () => {
   const handleOpenPicker = useCallback(async () => {
     const { status } = await ExpoImagePicker.requestMediaLibraryPermissionsAsync();
     if (status !== 'granted') {
-      Alert.alert('権限が必要', 'ギャラリーへのアクセスを許可してください');
+      Alert.alert(t('permissionRequired'), t('galleryPermissionMessage'));
       return;
     }
     const result = await ExpoImagePicker.launchImageLibraryAsync({
@@ -606,7 +607,7 @@ const MainScreen = () => {
     }
     const {status} = await MediaLibrary.requestPermissionsAsync(false, ['photo']);
     if (status !== 'granted') {
-      Alert.alert('権限が必要', 'カメラロールへのアクセスを許可してください');
+      Alert.alert(t('permissionRequired'), 'Please allow camera roll access.');
       return;
     }
     try {
@@ -1071,7 +1072,7 @@ const MainScreen = () => {
             style={styles.resetButton}
             onPress={handleReset}
             activeOpacity={0.7}>
-            <Text style={styles.resetButtonText}>リセット</Text>
+            <Text style={styles.resetButtonText}>Reset</Text>
           </TouchableOpacity>
         )}
 
@@ -1086,7 +1087,7 @@ const MainScreen = () => {
             style={styles.cancelButton}
             onPress={handleCancel}
             activeOpacity={0.8}>
-            <Text style={styles.cancelButtonText}>⛔ キャンセル</Text>
+            <Text style={styles.cancelButtonText}>⛔ Cancel</Text>
           </TouchableOpacity>
         )}
 
@@ -1108,7 +1109,7 @@ const MainScreen = () => {
               activeOpacity={0.8}
               accessibilityRole="button"
               accessibilityLabel="共有">
-              <Text style={styles.buttonText}>🔗 共有</Text>
+              <Text style={styles.buttonText}>🔗 Share</Text>
             </TouchableOpacity>
           </View>
         )}
@@ -1128,7 +1129,7 @@ const MainScreen = () => {
                 <Text style={styles.buttonText}> 処理中...</Text>
               </View>
             ) : (
-              <Text style={styles.buttonText}>変換</Text>
+              <Text style={styles.buttonText}>Convert</Text>
             )}
           </TouchableOpacity>
         ) : (


### PR DESCRIPTION
## 概要
Issue #16 の初期対応として、軽量なi18nヘルパーを導入し、主要UI文言を日本語/英語で切り替え可能にしました。

## 変更内容
- app/src/i18n.ts を追加し、端末ロケールに応じて ja/en 文言を返す t() を実装
- ErrorModal, ImagePicker, ResizeSlider の固定文言を t() 経由に変更
- MainScreen の一部操作文言・権限ダイアログを英語化可能な形へ変更

## テスト
- ローカルで npm run lint を試行したが、依存未インストール環境のため eslint: command not found で実行不可

Fixes #16