### PR TITLE
test: フォーマット変換網羅テストを追加

### DIFF
--- a/app/src/__tests__/FfmpegConverter.test.ts
+++ b/app/src/__tests__/FfmpegConverter.test.ts
@@ -23,6 +23,7 @@ jest.mock('expo-file-system/legacy', () => ({
 }));
 
 jest.mock('../data/ffmpeg/ffmpegUtils', () => ({
+  buildFfmpegCommand: jest.fn().mockImplementation((args: string[]) => args.filter(Boolean).join(' ')),
   generateUniqueFileSuffix: jest.fn().mockReturnValue('12345_abc'),
   extractErrorFromLogs: jest.fn().mockResolvedValue('mock logs'),
   getCacheDir: jest.fn().mockReturnValue('file:///cache/'),
@@ -44,6 +45,7 @@ describe('convertImage', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     const ffmpegUtils = jest.requireMock('../data/ffmpeg/ffmpegUtils');
+    ffmpegUtils.buildFfmpegCommand.mockImplementation((args: string[]) => args.filter(Boolean).join(' '));
     ffmpegUtils.generateUniqueFileSuffix.mockReturnValue('12345_abc');
     ffmpegUtils.extractErrorFromLogs.mockResolvedValue('mock logs');
     ffmpegUtils.getCacheDir.mockReturnValue('file:///cache/');
@@ -117,5 +119,34 @@ describe('convertImage', () => {
 
     await expect(convertImage('file:///photos/in.jpg', { outputFormat: 'webp' })).rejects.toThrow('FFmpegフォーマット変換に失敗しました');
     expect(mockDeleteAsync).toHaveBeenCalledWith('file:///cache/in_converted_12345_abc.webp', { idempotent: true });
+  });
+
+  it.each([
+    { outputFormat: 'jpeg' as const, expectedExt: '.jpg', expectedArg: '-q:v' },
+    { outputFormat: 'png' as const, expectedExt: '.png', expectedArg: '-compression_level 6' },
+    { outputFormat: 'webp' as const, expectedExt: '.webp', expectedArg: '-quality' },
+    { outputFormat: 'bmp' as const, expectedExt: '.bmp', expectedArg: '-frames:v 1' },
+  ])('主要フォーマット変換($outputFormat)で拡張子とコマンドが一致する', async ({ outputFormat, expectedExt, expectedArg }) => {
+    mockGetInfoAsync
+      .mockResolvedValueOnce({ exists: true, size: 1200 })
+      .mockResolvedValueOnce({ exists: true, size: 640 });
+
+    const result = await convertImage('file:///photos/input.png', { outputFormat, quality: 50 });
+
+    expect(result.outputUri).toBe(`file:///cache/input_converted_12345_abc${expectedExt}`);
+    expect(mockExecute.mock.calls[0][0]).toContain(expectedArg);
+  });
+
+  it('GIF変換で出力拡張子と2-pass経路が一致する', async () => {
+    mockGetInfoAsync
+      .mockResolvedValueOnce({ exists: true, size: 2000 })
+      .mockResolvedValueOnce({ exists: true, size: 800 });
+
+    const result = await convertImage('file:///photos/anim.webp', { outputFormat: 'gif' });
+
+    expect(result.outputUri).toBe('file:///cache/anim_converted_12345_abc.gif');
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+    expect(mockExecute.mock.calls[0][0]).toContain('palettegen');
+    expect(mockExecute.mock.calls[1][0]).toContain('paletteuse');
   });
 });

--- a/app/src/__tests__/FfmpegProcessor.test.ts
+++ b/app/src/__tests__/FfmpegProcessor.test.ts
@@ -43,6 +43,11 @@ function lastCmd() {
 describe('processWithFfmpeg', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    const ffmpegUtils = jest.requireMock('../data/ffmpeg/ffmpegUtils');
+    ffmpegUtils.generateUniqueFileSuffix.mockReturnValue('12345_abc');
+    ffmpegUtils.extractErrorFromLogs.mockResolvedValue('');
+    ffmpegUtils.getCacheDir.mockReturnValue('file:///cache/');
+    ffmpegUtils.getFileSizeBytes.mockImplementation((info: { size?: number }) => info?.size ?? 0);
     setupSuccess();
   });
 
@@ -82,11 +87,34 @@ describe('processWithFfmpeg', () => {
     expect(mockExecute).toHaveBeenCalledTimes(3);
     expect(mockMoveAsync).toHaveBeenCalled();
   });
+
+  it.each([
+    { input: 'file:///in.jpg', expectedExt: '.jpg' },
+    { input: 'file:///in.png', expectedExt: '.jpg' },
+    { input: 'file:///in.webp', expectedExt: '.webp' },
+    { input: 'file:///in.bmp', expectedExt: '.bmp' },
+    { input: 'file:///in.gif', expectedExt: '.gif' },
+  ])('gabigabi経路で出力拡張子が期待通り($input)', async ({ input, expectedExt }) => {
+    mockGetInfoAsync
+      .mockResolvedValueOnce({ exists: true, size: 1000 })
+      .mockResolvedValueOnce({ exists: true, size: 500 });
+
+    const result = await processWithFfmpeg(input, 80, 2);
+
+    expect(result.outputUri).toBe(`file:///cache/in_gabigabi_12345_abc${expectedExt}`);
+    expect(lastCmd()).toContain(`in_gabigabi_12345_abc${expectedExt}`);
+    expect(lastCmd()).toContain('-q:v 18');
+  });
 });
 
 describe('processVideoWithFfmpeg', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    const ffmpegUtils = jest.requireMock('../data/ffmpeg/ffmpegUtils');
+    ffmpegUtils.generateUniqueFileSuffix.mockReturnValue('12345_abc');
+    ffmpegUtils.extractErrorFromLogs.mockResolvedValue('');
+    ffmpegUtils.getCacheDir.mockReturnValue('file:///cache/');
+    ffmpegUtils.getFileSizeBytes.mockImplementation((info: { size?: number }) => info?.size ?? 0);
     setupSuccess();
   });
 


### PR DESCRIPTION
## 概要\n- format-only 経路（FfmpegConverter）の出力フォーマット別テストを追加\n- GIF 2-pass（palettegen/paletteuse）経路の拡張子・コマンド検証を追加\n- gabigabi/resize 経路（FfmpegProcessor）の入力拡張子別出力拡張子テストを追加\n\n## テスト\n- npm test -- --runInBand src/__tests__/FfmpegConverter.test.ts src/__tests__/FfmpegProcessor.test.ts\n\nFixes #74