### PR TITLE
test: 全フォーマット変換パターンの網羅テストを追加

### DIFF
--- a/app/src/__tests__/FfmpegConverter.test.ts
+++ b/app/src/__tests__/FfmpegConverter.test.ts
@@ -23,6 +23,7 @@ jest.mock('expo-file-system/legacy', () => ({
 }));
 
 jest.mock('../data/ffmpeg/ffmpegUtils', () => ({
+  buildFfmpegCommand: jest.fn().mockImplementation((parts: string[]) => parts.filter(Boolean).join(' ')),
   generateUniqueFileSuffix: jest.fn().mockReturnValue('12345_abc'),
   extractErrorFromLogs: jest.fn().mockResolvedValue('mock logs'),
   getCacheDir: jest.fn().mockReturnValue('file:///cache/'),
@@ -44,6 +45,7 @@ describe('convertImage', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     const ffmpegUtils = jest.requireMock('../data/ffmpeg/ffmpegUtils');
+    ffmpegUtils.buildFfmpegCommand.mockImplementation((parts: string[]) => parts.filter(Boolean).join(' '));
     ffmpegUtils.generateUniqueFileSuffix.mockReturnValue('12345_abc');
     ffmpegUtils.extractErrorFromLogs.mockResolvedValue('mock logs');
     ffmpegUtils.getCacheDir.mockReturnValue('file:///cache/');
@@ -70,6 +72,25 @@ describe('convertImage', () => {
     await convertImage('file:///photos/in.jpg', { outputFormat: 'png' });
 
     expect(mockExecute.mock.calls[0][0]).toContain('-compression_level 6');
+  });
+
+  it.each([
+    { format: 'jpeg', expectedExt: '.jpg', qualityArg: '-q:v' },
+    { format: 'png', expectedExt: '.png', qualityArg: '-compression_level 6' },
+    { format: 'webp', expectedExt: '.webp', qualityArg: '-quality' },
+    { format: 'bmp', expectedExt: '.bmp', qualityArg: '' },
+  ])('主要フォーマット変換を網羅できる: $format', async ({ format, expectedExt, qualityArg }) => {
+    mockGetInfoAsync
+      .mockResolvedValueOnce({ exists: true, size: 1000 })
+      .mockResolvedValueOnce({ exists: true, size: 600 });
+
+    const result = await convertImage('file:///photos/input.png', { outputFormat: format as 'jpeg' | 'png' | 'webp' | 'bmp' });
+    const cmd = mockExecute.mock.calls[0][0] as string;
+
+    expect(result.outputUri).toMatch(new RegExp(`${expectedExt.replace('.', '\\.')}$`));
+    if (qualityArg) {
+      expect(cmd).toContain(qualityArg);
+    }
   });
 
   it('GIF変換時に2パス実行しパレットを削除する', async () => {

--- a/app/src/__tests__/FfmpegProcessor.test.ts
+++ b/app/src/__tests__/FfmpegProcessor.test.ts
@@ -43,6 +43,11 @@ function lastCmd() {
 describe('processWithFfmpeg', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    const ffmpegUtils = jest.requireMock('../data/ffmpeg/ffmpegUtils');
+    ffmpegUtils.generateUniqueFileSuffix.mockReturnValue('12345_abc');
+    ffmpegUtils.extractErrorFromLogs.mockResolvedValue('');
+    ffmpegUtils.getCacheDir.mockReturnValue('file:///cache/');
+    ffmpegUtils.getFileSizeBytes.mockImplementation((info: { size?: number }) => info?.size ?? 0);
     setupSuccess();
   });
 
@@ -82,11 +87,34 @@ describe('processWithFfmpeg', () => {
     expect(mockExecute).toHaveBeenCalledTimes(3);
     expect(mockMoveAsync).toHaveBeenCalled();
   });
+
+
+  it.each([
+    { input: 'file:///in.jpeg', outExt: '.jpeg' },
+    { input: 'file:///in.png', outExt: '.jpg' },
+    { input: 'file:///in.webp', outExt: '.webp' },
+    { input: 'file:///in.bmp', outExt: '.bmp' },
+    { input: 'file:///in.gif', outExt: '.gif' },
+  ])('gabigabi/resize経路の出力拡張子を維持する（$input）', async ({ input, outExt }) => {
+    mockGetInfoAsync
+      .mockResolvedValueOnce({ exists: true, size: 1000 })
+      .mockResolvedValueOnce({ exists: true, size: 700 });
+
+    const result = await processWithFfmpeg(input, 80, 2);
+
+    expect(result.outputUri).toMatch(new RegExp(`${outExt.replace('.', '\\.')}$`));
+    expect(lastCmd()).toContain('-q:v');
+  });
 });
 
 describe('processVideoWithFfmpeg', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    const ffmpegUtils = jest.requireMock('../data/ffmpeg/ffmpegUtils');
+    ffmpegUtils.generateUniqueFileSuffix.mockReturnValue('12345_abc');
+    ffmpegUtils.extractErrorFromLogs.mockResolvedValue('');
+    ffmpegUtils.getCacheDir.mockReturnValue('file:///cache/');
+    ffmpegUtils.getFileSizeBytes.mockImplementation((info: { size?: number }) => info?.size ?? 0);
     setupSuccess();
   });
 


### PR DESCRIPTION
## 概要
- `convertImage` の主要出力フォーマット（jpeg/png/webp/bmp）を表形式で網羅
- GIF 2-pass 経路の既存検証に加え、各フォーマットで拡張子とコマンド引数を確認
- `processWithFfmpeg`（gabigabi/resize経路）で入力拡張子ごとの出力拡張子を検証（png→jpg変換を含む）

## テスト
- `npm test -- --runInBand src/__tests__/FfmpegConverter.test.ts src/__tests__/FfmpegProcessor.test.ts`

Fixes #74