### PR TITLE
[i18n] BEFORE/AFTERラベルをi18nキーへ移行する

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -701,7 +701,7 @@ const MainScreen = () => {
         <View style={styles.previewRow}>
           <View style={styles.previewColumn}>
             <PreviewCard
-              label="BEFORE"
+              label={t('before')}
               uri={selectedImage}
               mediaType={selectedMediaType ?? 'image'}
               placeholder={''}
@@ -724,7 +724,7 @@ const MainScreen = () => {
           </View>
           <View style={styles.previewColumn}>
             <PreviewCard
-              label="AFTER"
+              label={t('after')}
               uri={processedImage}
               mediaType={selectedMediaType === 'video' ? 'video' : 'image'}
               placeholder={selectedImage ? t('converted') : '—'}


### PR DESCRIPTION
Closes #78

## 変更内容
- `i18n.ts` の `DICT` に `before`・`after` キーを追加（ja: 変換前/変換後、en: BEFORE/AFTER）
- `MainScreen.tsx` の `label="BEFORE"` → `label={t('before')}`、`label="AFTER"` → `label={t('after')}` に置換