### PR TITLE
[Test] useResizeImage (resizeImage関数) のユニットテストを追加

### DIFF
--- a/app/src/__tests__/useResizeImage.test.ts
+++ b/app/src/__tests__/useResizeImage.test.ts
@@ -1,0 +1,67 @@
+import { resizeImage } from '../domain/useResizeImage';
+
+const mockProcessWithFfmpeg = jest.fn();
+
+jest.mock('../data/ffmpeg/FfmpegProcessor', () => ({
+  processWithFfmpeg: (...args: unknown[]) => mockProcessWithFfmpeg(...args),
+}));
+
+describe('resizeImage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProcessWithFfmpeg.mockResolvedValue({
+      outputUri: 'file:///output/result.jpg',
+      outputBytes: 12345,
+    });
+  });
+
+  it('returns outputUri, outputBytes, and engine="ffmpeg" from processWithFfmpeg result', async () => {
+    const result = await resizeImage('file:///input/test.jpg', 50, 2);
+    expect(result).toEqual({
+      outputUri: 'file:///output/result.jpg',
+      outputBytes: 12345,
+      engine: 'ffmpeg',
+    });
+  });
+
+  it('passes inputUri, scalePct, and gabigabiLevel to processWithFfmpeg', async () => {
+    await resizeImage('file:///input/test.jpg', 75, 3);
+    expect(mockProcessWithFfmpeg).toHaveBeenCalledWith(
+      'file:///input/test.jpg',
+      75,
+      3,
+      {},
+    );
+  });
+
+  it('passes options to processWithFfmpeg', async () => {
+    const options = {
+      shrinkExpandEnabled: true,
+      shrinkExpandRate: 50,
+      multiCompressEnabled: true,
+      multiCompressCount: 5,
+    };
+    await resizeImage('file:///input/test.jpg', 80, 2, options);
+    expect(mockProcessWithFfmpeg).toHaveBeenCalledWith(
+      'file:///input/test.jpg',
+      80,
+      2,
+      options,
+    );
+  });
+
+  it('uses gabigabiLevel default of 2 when not specified', async () => {
+    await resizeImage('file:///input/test.jpg', 60);
+    expect(mockProcessWithFfmpeg).toHaveBeenCalledWith(
+      'file:///input/test.jpg',
+      60,
+      2,
+      {},
+    );
+  });
+
+  it('propagates error when processWithFfmpeg throws', async () => {
+    mockProcessWithFfmpeg.mockRejectedValue(new Error('FFmpeg error'));
+    await expect(resizeImage('file:///input/test.jpg', 50, 2)).rejects.toThrow('FFmpeg error');
+  });
+});


### PR DESCRIPTION
Closes #79

## 変更内容
`app/src/__tests__/useResizeImage.test.ts` を新規作成。

## テスト内容
1. `processWithFfmpeg` をmockして `resizeImage` が返す `{outputUri, outputBytes, engine}` が期待値と一致することを確認
2. オプション（`shrinkExpandEnabled`, `multiCompressEnabled` など）が `processWithFfmpeg` に正しく渡されることを確認
3. `gabigabiLevel` のデフォルト値（2）が正しく渡されることを確認
4. `processWithFfmpeg` がエラーをthrowした場合に `resizeImage` もエラーを伝播することを確認