### PR TITLE
test: CustomSlider コンポーネントのユニットテストを追加 (#87)

### DIFF
--- a/app/src/__tests__/CustomSlider.test.tsx
+++ b/app/src/__tests__/CustomSlider.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * CustomSlider コンポーネントのユニットテスト
+ * Issue #87
+ */
+
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import CustomSlider from '../components/CustomSlider';
+
+describe('CustomSlider', () => {
+  const defaultProps = {
+    minimumValue: 0,
+    maximumValue: 100,
+    value: 50,
+    onValueChange: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('レンダリング', () => {
+    it('デフォルト props で正常にレンダリングされる', async () => {
+      let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+      await ReactTestRenderer.act(() => {
+        renderer = ReactTestRenderer.create(<CustomSlider {...defaultProps} />);
+      });
+      expect(renderer!.toJSON()).not.toBeNull();
+    });
+
+    it('accessibilityRole が "adjustable" である', async () => {
+      let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+      await ReactTestRenderer.act(() => {
+        renderer = ReactTestRenderer.create(
+          <CustomSlider {...defaultProps} accessibilityLabel="テストスライダー" />,
+        );
+      });
+      const instance = renderer!.root;
+      const container = instance.findAll(
+        el => el.props.accessibilityRole === 'adjustable',
+      );
+      expect(container.length).toBeGreaterThan(0);
+    });
+
+    it('accessibilityLabel が props から反映される', async () => {
+      const label = 'リサイズスライダー';
+      let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+      await ReactTestRenderer.act(() => {
+        renderer = ReactTestRenderer.create(
+          <CustomSlider {...defaultProps} accessibilityLabel={label} />,
+        );
+      });
+      const instance = renderer!.root;
+      const el = instance.find(e => e.props.accessibilityLabel === label);
+      expect(el).toBeTruthy();
+    });
+  });
+
+  describe('value に応じたスタイル', () => {
+    it('value=0 のときクラッシュしない', async () => {
+      let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+      await ReactTestRenderer.act(() => {
+        renderer = ReactTestRenderer.create(
+          <CustomSlider {...defaultProps} value={0} />,
+        );
+      });
+      expect(renderer!.toJSON()).not.toBeNull();
+    });
+
+    it('value=maximumValue のときクラッシュしない', async () => {
+      let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+      await ReactTestRenderer.act(() => {
+        renderer = ReactTestRenderer.create(
+          <CustomSlider {...defaultProps} value={100} />,
+        );
+      });
+      expect(renderer!.toJSON()).not.toBeNull();
+    });
+
+    it('minimumValue === maximumValue のとき NaN にならずレンダリングされる', async () => {
+      let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+      await ReactTestRenderer.act(() => {
+        renderer = ReactTestRenderer.create(
+          <CustomSlider
+            minimumValue={50}
+            maximumValue={50}
+            value={50}
+            onValueChange={jest.fn()}
+          />,
+        );
+      });
+      expect(renderer!.toJSON()).not.toBeNull();
+    });
+  });
+
+  describe('カスタムカラー', () => {
+    it('minimumTrackTintColor / maximumTrackTintColor / thumbTintColor が反映される', async () => {
+      let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+      await ReactTestRenderer.act(() => {
+        renderer = ReactTestRenderer.create(
+          <CustomSlider
+            {...defaultProps}
+            minimumTrackTintColor="#00ff00"
+            maximumTrackTintColor="#0000ff"
+            thumbTintColor="#ff0000"
+          />,
+        );
+      });
+      const json = renderer!.toJSON() as any;
+      // thumb の backgroundColor は thumbTintColor
+      const thumb = renderer!.root.findAll(
+        el =>
+          el.props.style &&
+          JSON.stringify(el.props.style).includes('#ff0000'),
+      );
+      expect(thumb.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('step プロパティ', () => {
+    it('step=10 で正常にレンダリングされる', async () => {
+      let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+      await ReactTestRenderer.act(() => {
+        renderer = ReactTestRenderer.create(
+          <CustomSlider
+            minimumValue={0}
+            maximumValue={100}
+            step={10}
+            value={50}
+            onValueChange={jest.fn()}
+          />,
+        );
+      });
+      expect(renderer!.toJSON()).not.toBeNull();
+    });
+
+    it('step=0 でもクラッシュしない', async () => {
+      let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+      await ReactTestRenderer.act(() => {
+        renderer = ReactTestRenderer.create(
+          <CustomSlider {...defaultProps} step={0} />,
+        );
+      });
+      expect(renderer!.toJSON()).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## 概要

Issue #87 対応。CustomSlider コンポーネントのユニットテストを追加する。

## 変更内容

- `app/src/__tests__/CustomSlider.test.tsx` を新規作成
- テスト項目:
  - レンダリング（デフォルト props、accessibilityRole、accessibilityLabel）
  - value に応じたスタイル（value=0、value=max、min===max で NaN にならない）
  - カスタムカラー（minimumTrackTintColor / maximumTrackTintColor / thumbTintColor）
  - step プロパティ（step=10、step=0）

## テスト結果

9 テスト全通過