### PR TITLE
refactor: MainScreen.tsx の残存インラインスタイルとマジック定数をsharedStylesへ移動

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -38,15 +38,9 @@ import {BeforeInfoBlock, AfterInfoBlock} from './components/ImageInfoBlock';
 import SettingsPanel from './components/SettingsPanel';
 import TargetSizePanel from './components/TargetSizePanel';
 import AboutModal from './components/AboutModal';
+import {DARK_BG, CARD_BG, ACCENT, ACCENT2, TEXT_PRIMARY, TEXT_SECONDARY, BORDER} from './components/sharedStyles';
 
-/* ── Constants ── */
-const DARK_BG = '#0d0d0d';
-const CARD_BG = '#1a1a1a';
-const ACCENT = '#ff4e50';
-const ACCENT2 = '#fc913a';
-const TEXT_PRIMARY = '#f0f0f0';
-const TEXT_SECONDARY = '#888';
-const BORDER = '#2a2a2a';
+/* ── Constants are now imported from sharedStyles ── */
 
 // テンプレートレベルに対応する設定値
 const TEMPLATE_SETTINGS: Record<number, {
@@ -639,15 +633,15 @@ const MainScreen = () => {
       {/* ── Header ── */}
       <View style={styles.header}>
         <View style={styles.headerRow}>
-          <View style={{flexDirection: 'column', alignItems: 'center', flex: 1, paddingHorizontal: 30}}>
+          <View style={styles.headerTitleBlock}>
             <Text style={styles.appName} numberOfLines={1} adjustsFontSizeToFit>GabiGabi</Text>
             <Text style={styles.appSubtitle} numberOfLines={1} adjustsFontSizeToFit>{t('appSubtitle')}</Text>
           </View>
           <TouchableOpacity
             onPress={() => setAboutVisible(true)}
-            style={{position: 'absolute', right: 0, padding: 8}}
+            style={styles.aboutButton}
           >
-            <Text style={{fontSize: 20, color: '#aaa'}}>ℹ️</Text>
+            <Text style={styles.aboutButtonIcon}>ℹ️</Text>
           </TouchableOpacity>
         </View>
       </View>
@@ -860,6 +854,21 @@ const styles = StyleSheet.create({
   headerRow: {
     flexDirection: 'row' as const,
     alignItems: 'center' as const,
+  },
+  headerTitleBlock: {
+    flexDirection: 'column' as const,
+    alignItems: 'center' as const,
+    flex: 1,
+    paddingHorizontal: 30,
+  },
+  aboutButton: {
+    position: 'absolute' as const,
+    right: 0,
+    padding: 8,
+  },
+  aboutButtonIcon: {
+    fontSize: 20,
+    color: '#aaa',
   },
   appName: {
     fontSize: 22,

--- a/app/src/screens/components/AboutModal.tsx
+++ b/app/src/screens/components/AboutModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import {View, Text, TouchableOpacity, Modal, Linking} from 'react-native';
+import {View, Text, TouchableOpacity, Modal, Linking, StyleSheet} from 'react-native';
 import {t} from '../../i18n';
+import {ACCENT, BORDER} from './sharedStyles';
 
 interface AboutModalProps {
   visible: boolean;
@@ -9,22 +10,80 @@ interface AboutModalProps {
 
 const AboutModal: React.FC<AboutModalProps> = ({visible, onClose}) => (
   <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-    <View style={{flex: 1, backgroundColor: 'rgba(0,0,0,0.7)', justifyContent: 'center', alignItems: 'center', padding: 24}}>
-      <View style={{backgroundColor: '#1e1e1e', borderRadius: 16, padding: 24, width: '100%', maxWidth: 360}}>
-        <Text style={{color: '#fff', fontSize: 24, fontWeight: 'bold', marginBottom: 4, textAlign: 'center'}}>GabiGabi</Text>
-        <Text style={{color: '#ccc', fontSize: 14, marginBottom: 16, textAlign: 'center'}}>{t('appSubtitle')}</Text>
-        <Text style={{color: '#ccc', fontSize: 14, marginBottom: 8}}>{t('appDescription')}</Text>
-        <Text style={{color: '#ccc', fontSize: 14, marginBottom: 8}}>{t('license')}</Text>
-        <Text style={{color: '#ccc', fontSize: 14, marginBottom: 8}}>{t('ffmpegUsage')}</Text>
+    <View style={styles.overlay}>
+      <View style={styles.dialog}>
+        <Text style={styles.title}>GabiGabi</Text>
+        <Text style={styles.subtitle}>{t('appSubtitle')}</Text>
+        <Text style={styles.bodyText}>{t('appDescription')}</Text>
+        <Text style={styles.bodyText}>{t('license')}</Text>
+        <Text style={styles.bodyText}>{t('ffmpegUsage')}</Text>
         <TouchableOpacity onPress={() => { Linking.openURL('https://github.com/e-komiya/gabigabi'); }}>
-          <Text style={{color: '#4da6ff', fontSize: 14, marginBottom: 16}}>{t('viewSourceOnGitHub')}</Text>
+          <Text style={styles.link}>{t('viewSourceOnGitHub')}</Text>
         </TouchableOpacity>
-        <TouchableOpacity onPress={onClose} style={{backgroundColor: '#333', borderRadius: 8, padding: 12, alignItems: 'center'}}>
-          <Text style={{color: '#fff', fontSize: 16}}>{t('close')}</Text>
+        <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+          <Text style={styles.closeButtonText}>{t('close')}</Text>
         </TouchableOpacity>
       </View>
     </View>
   </Modal>
 );
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  dialog: {
+    backgroundColor: '#1e1e1e',
+    borderRadius: 16,
+    padding: 24,
+    width: '100%',
+    maxWidth: 360,
+    borderWidth: 1,
+    borderColor: BORDER,
+  },
+  title: {
+    color: '#fff',
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 4,
+    textAlign: 'center',
+  },
+  subtitle: {
+    color: '#ccc',
+    fontSize: 14,
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  bodyText: {
+    color: '#ccc',
+    fontSize: 14,
+    marginBottom: 8,
+  },
+  link: {
+    color: '#4da6ff',
+    fontSize: 14,
+    marginBottom: 16,
+  },
+  closeButton: {
+    backgroundColor: '#333',
+    borderRadius: 8,
+    padding: 12,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: BORDER,
+  },
+  closeButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  accentText: {
+    color: ACCENT,
+  },
+});
 
 export default AboutModal;

--- a/app/src/screens/components/TargetSizePanel.tsx
+++ b/app/src/screens/components/TargetSizePanel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {View, Text, TouchableOpacity, TextInput, StyleSheet} from 'react-native';
 import {SizeUnit} from '../../state/store';
 import {t} from '../../i18n';
-import {sharedStyles, BORDER, TEXT_SECONDARY} from './sharedStyles';
+import {sharedStyles, BORDER, TEXT_SECONDARY, DARK_BG} from './sharedStyles';
 
 const TARGET_SIZE_TEMPLATES: {label: string; value: string; unit: SizeUnit}[] = [
   {label: 'Discord 10MB', value: '10', unit: 'MB'},
@@ -50,7 +50,7 @@ const TargetSizePanel: React.FC<TargetSizePanelProps> = ({
         </View>
       </View>
 
-      <Text style={[sharedStyles.sectionTitle, {marginTop: 20}]}>{t('template')}</Text>
+      <Text style={[sharedStyles.sectionTitle, styles.templateTitle]}>{t('template')}</Text>
       <View style={styles.targetSizeTemplates}>
         {TARGET_SIZE_TEMPLATES.map(tmpl => (
           <TouchableOpacity
@@ -62,7 +62,7 @@ const TargetSizePanel: React.FC<TargetSizePanelProps> = ({
         ))}
       </View>
 
-      <Text style={{color: '#666', fontSize: 12, marginTop: 16, lineHeight: 18}}>
+      <Text style={styles.noteText}>
         {t('targetSizeNote')}
       </Text>
     </View>
@@ -70,6 +70,15 @@ const TargetSizePanel: React.FC<TargetSizePanelProps> = ({
 };
 
 const styles = StyleSheet.create({
+  templateTitle: {
+    marginTop: 20,
+  },
+  noteText: {
+    color: '#666',
+    fontSize: 12,
+    marginTop: 16,
+    lineHeight: 18,
+  },
   targetSizeInputRow: {
     flexDirection: 'row',
     gap: 12,


### PR DESCRIPTION
## 概要
issue #95 の対応。

## 変更内容
- **AboutModal.tsx**: 全インラインスタイルを `StyleSheet.create` に移行し、BORDER定数を活用
- **TargetSizePanel.tsx**: 残存インラインスタイル（`marginTop: 20`, noteText）を `StyleSheet` に移動
- **MainScreen.tsx**: ヘッダー部分のインラインスタイル（headerTitleBlock, aboutButton, aboutButtonIcon）を名前付きスタイルに変換
- **MainScreen.tsx**: 重複していたカラー定数を `sharedStyles` からインポートするよう変更（DRY原則）

Closes #95