### PR TITLE
a11y: サブコンポーネントにアクセシビリティ属性を追加（PreviewCard, AboutModal, ImageInfoBlock）

### DIFF
--- a/app/src/screens/components/AboutModal.tsx
+++ b/app/src/screens/components/AboutModal.tsx
@@ -9,18 +9,32 @@ interface AboutModalProps {
 }
 
 const AboutModal: React.FC<AboutModalProps> = ({visible, onClose}) => (
-  <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-    <View style={styles.overlay}>
-      <View style={styles.dialog}>
-        <Text style={styles.title}>GabiGabi</Text>
+  <Modal
+    visible={visible}
+    transparent
+    animationType="fade"
+    onRequestClose={onClose}
+    accessibilityViewIsModal
+    accessibilityLabel={t('appDescription')}>
+    <View style={styles.overlay} accessible={false}>
+      <View style={styles.dialog} accessibilityRole="summary" accessible>
+        <Text style={styles.title} accessibilityRole="header">GabiGabi</Text>
         <Text style={styles.subtitle}>{t('appSubtitle')}</Text>
         <Text style={styles.bodyText}>{t('appDescription')}</Text>
         <Text style={styles.bodyText}>{t('license')}</Text>
         <Text style={styles.bodyText}>{t('ffmpegUsage')}</Text>
-        <TouchableOpacity onPress={() => { Linking.openURL('https://github.com/e-komiya/gabigabi'); }}>
+        <TouchableOpacity
+          onPress={() => { Linking.openURL('https://github.com/e-komiya/gabigabi'); }}
+          accessibilityRole="link"
+          accessibilityLabel={t('viewSourceOnGitHub')}
+          accessibilityHint="GitHubのリポジトリページをブラウザで開きます">
           <Text style={styles.link}>{t('viewSourceOnGitHub')}</Text>
         </TouchableOpacity>
-        <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+        <TouchableOpacity
+          onPress={onClose}
+          style={styles.closeButton}
+          accessibilityRole="button"
+          accessibilityLabel={t('close')}>
           <Text style={styles.closeButtonText}>{t('close')}</Text>
         </TouchableOpacity>
       </View>

--- a/app/src/screens/components/ImageInfoBlock.tsx
+++ b/app/src/screens/components/ImageInfoBlock.tsx
@@ -38,7 +38,11 @@ const styles = StyleSheet.create({
 });
 
 export const BeforeInfoBlock: React.FC<BeforeInfoBlockProps> = ({fileInfo}) => (
-  <View style={styles.infoBlock}>
+  <View
+    style={styles.infoBlock}
+    accessible
+    accessibilityRole="summary"
+    accessibilityLabel={`変換前: ${fileInfo.name}, サイズ ${fileInfo.size}${fileInfo.width > 0 ? `, 解像度 ${fileInfo.width} × ${fileInfo.height} ピクセル` : ''}`}>
     <Text style={styles.infoText} numberOfLines={1} ellipsizeMode="middle">📄 {fileInfo.name}</Text>
     <Text style={styles.infoText}>{fileInfo.size}</Text>
     {fileInfo.width > 0 && (
@@ -55,19 +59,32 @@ export const AfterInfoBlock: React.FC<AfterInfoBlockProps> = ({
   resizePercent,
   outputFormat,
   showAfterConversion,
-}) => (
-  <View style={styles.infoBlock}>
-    <Text style={styles.infoText} numberOfLines={1} ellipsizeMode="middle">
-      📄 {processedImage ? processedImage.split('/').pop() : '—'}
-    </Text>
-    <Text style={styles.infoText}>
-      {processedImage ? outputBytesFormatted : showAfterConversion}
-    </Text>
-    <Text style={styles.infoText}>
-      {Math.round(fileInfo.width * resizePercent / 100)} × {Math.round(fileInfo.height * resizePercent / 100)} px
-    </Text>
-    <Text style={styles.infoText}>
-      🏷 {processedImage ? (processedImage.split('.').pop()?.toUpperCase() ?? outputFormat.toUpperCase()) : outputFormat.toUpperCase()}
-    </Text>
-  </View>
-);
+}) => {
+  const filename = processedImage ? processedImage.split('/').pop() : '—';
+  const sizeLabel = processedImage ? outputBytesFormatted : showAfterConversion;
+  const resizedW = Math.round(fileInfo.width * resizePercent / 100);
+  const resizedH = Math.round(fileInfo.height * resizePercent / 100);
+  const fmtLabel = processedImage ? (processedImage.split('.').pop()?.toUpperCase() ?? outputFormat.toUpperCase()) : outputFormat.toUpperCase();
+  return (
+    <View
+      style={styles.infoBlock}
+      accessible
+      accessibilityRole="summary"
+      accessibilityLabel={processedImage
+        ? `変換後: ${filename}, サイズ ${sizeLabel}, 解像度 ${resizedW} × ${resizedH} ピクセル, フォーマット ${fmtLabel}`
+        : showAfterConversion}>
+      <Text style={styles.infoText} numberOfLines={1} ellipsizeMode="middle">
+        📄 {filename}
+      </Text>
+      <Text style={styles.infoText}>
+        {sizeLabel}
+      </Text>
+      <Text style={styles.infoText}>
+        {resizedW} × {resizedH} px
+      </Text>
+      <Text style={styles.infoText}>
+        🏷 {fmtLabel}
+      </Text>
+    </View>
+  );
+};

--- a/app/src/screens/components/PreviewCard.tsx
+++ b/app/src/screens/components/PreviewCard.tsx
@@ -15,20 +15,38 @@ export interface PreviewCardProps {
 }
 
 const PreviewCard: React.FC<PreviewCardProps> = ({label, uri, mediaType = 'image', placeholder, onImagePress, onPickerPress}) => (
-  <View style={styles.previewCard}>
+  <View
+    style={styles.previewCard}
+    accessible={false}>
     <View style={styles.previewLabelRow}>
-      <Text style={styles.previewLabel}>{label}</Text>
+      <Text style={styles.previewLabel} accessibilityRole="header">{label}</Text>
     </View>
     {uri ? (
       mediaType === 'video' ? (
-        <View style={[styles.previewEmpty, styles.videoPreview]}>
+        <View
+          style={[styles.previewEmpty, styles.videoPreview]}
+          accessible
+          accessibilityRole="image"
+          accessibilityLabel={`${label}: ${t('video')}`}>
           <Text style={styles.videoPreviewIcon}>🎬</Text>
           <Text style={styles.videoPreviewText}>{t('video')}</Text>
         </View>
       ) : (
-        <TouchableOpacity onPress={() => onPickerPress ? onPickerPress() : onImagePress?.(uri)} activeOpacity={0.85}>
-          <Image source={{uri}} style={styles.previewImage} resizeMode="cover" />
-          <View style={styles.svgOverlay}>
+        <TouchableOpacity
+          onPress={() => onPickerPress ? onPickerPress() : onImagePress?.(uri)}
+          activeOpacity={0.85}
+          accessibilityRole="button"
+          accessibilityLabel={onPickerPress ? t('changeImage') : `${label} ${t('tapToZoom')}`}
+          accessibilityHint={onPickerPress ? t('tapToOpenGallery') : t('tapToZoom')}>
+          <Image
+            source={{uri}}
+            style={styles.previewImage}
+            resizeMode="cover"
+            accessible
+            accessibilityRole="image"
+            accessibilityLabel={`${label} ${t('tapToZoom')}`}
+          />
+          <View style={styles.svgOverlay} accessible={false} importantForAccessibility="no-hide-descendants">
             {onPickerPress && (
               <Svg width="100%" height="100%" viewBox="0 0 640 640">
                 <Path
@@ -39,14 +57,20 @@ const PreviewCard: React.FC<PreviewCardProps> = ({label, uri, mediaType = 'image
               </Svg>
             )}
           </View>
-          <View style={styles.previewTapHint}>
+          <View style={styles.previewTapHint} accessible={false} importantForAccessibility="no-hide-descendants">
             <Text style={styles.previewTapHintText}>🔍 {t('tapToZoom')}</Text>
           </View>
         </TouchableOpacity>
       )
     ) : (
-      <TouchableOpacity onPress={onPickerPress} activeOpacity={0.7} style={styles.previewEmptyTouchable}>
-        <Text style={styles.previewEmptyIcon}>＋</Text>
+      <TouchableOpacity
+        onPress={onPickerPress}
+        activeOpacity={0.7}
+        style={styles.previewEmptyTouchable}
+        accessibilityRole="button"
+        accessibilityLabel={t('pickImageOrVideo')}
+        accessibilityHint={t('tapToOpenGallery')}>
+        <Text style={styles.previewEmptyIcon} accessible={false}>＋</Text>
         <Text style={styles.previewEmptyText}>{placeholder || t('selectImageOrVideo')}</Text>
       </TouchableOpacity>
     )}


### PR DESCRIPTION
## 概要
issue #94 の対応。スクリーンリーダー対応のため、主要サブコンポーネントにアクセシビリティ属性を追加しました。

## 変更内容

### PreviewCard.tsx
- 画像プレビュー: `accessibilityRole="image"`, `accessibilityLabel` 追加
- 動画プレビュー: `accessibilityRole="image"`, `accessibilityLabel` 追加
- 画像タップボタン: `accessibilityRole="button"`, `accessibilityLabel`, `accessibilityHint` 追加
- 空ボタン（ピッカー起動）: `accessibilityRole="button"`, `accessibilityLabel`, `accessibilityHint` 追加
- デコレーション用SVGとタップヒントを `importantForAccessibility="no-hide-descendants"` で非表示化

### AboutModal.tsx
- Modal: `accessibilityViewIsModal` 追加
- タイトル: `accessibilityRole="header"` 追加
- GitHubリンク: `accessibilityRole="link"`, `accessibilityHint` 追加
- 閉じるボタン: `accessibilityRole="button"`, `accessibilityLabel` 追加

### ImageInfoBlock.tsx
- BeforeInfoBlock/AfterInfoBlock: `accessibilityRole="summary"`, `accessibilityLabel` 追加でファイル情報を一括読み上げ可能に

Closes #94