### PR TITLE
a11y: app/src/components/ 配下コンポーネントにアクセシビリティ属性を追加 (#99)

### DIFF
--- a/app/src/components/ErrorModal.tsx
+++ b/app/src/components/ErrorModal.tsx
@@ -43,12 +43,13 @@ const ErrorModal: React.FC<ErrorModalProps> = ({
       visible={visible}
       transparent
       animationType="fade"
-      onRequestClose={onClose}>
+      onRequestClose={onClose}
+      accessibilityViewIsModal={true}>
       <View style={styles.overlay}>
         <View style={styles.dialog}>
           {/* Title */}
           <View style={styles.titleRow}>
-            <Text style={styles.titleText}>{title}</Text>
+            <Text style={styles.titleText} accessibilityRole="header">{title}</Text>
           </View>
 
           {/* Scrollable error body */}
@@ -66,7 +67,9 @@ const ErrorModal: React.FC<ErrorModalProps> = ({
             <TouchableOpacity
               style={[styles.copyButton, copied && styles.copyButtonDone]}
               onPress={handleCopy}
-              activeOpacity={0.8}>
+              activeOpacity={0.8}
+              accessibilityRole="button"
+              accessibilityLabel={copied ? t('copied') : t('copy')}>
               <Text style={styles.copyButtonText}>
                 {copied ? t('copied') : t('copy')}
               </Text>
@@ -75,7 +78,9 @@ const ErrorModal: React.FC<ErrorModalProps> = ({
             <TouchableOpacity
               style={styles.closeButton}
               onPress={onClose}
-              activeOpacity={0.8}>
+              activeOpacity={0.8}
+              accessibilityRole="button"
+              accessibilityLabel={t('close')}>
               <Text style={styles.closeButtonText}>{t('close')}</Text>
             </TouchableOpacity>
           </View>

--- a/app/src/components/FileSizeLabel.tsx
+++ b/app/src/components/FileSizeLabel.tsx
@@ -45,9 +45,12 @@ const FileSizeLabel: React.FC<FileSizeLabelProps> = ({label, uri}) => {
   }
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.label}>{label}</Text>
-      <Text style={styles.value}>{size}</Text>
+    <View
+      style={styles.container}
+      accessible={true}
+      accessibilityLabel={`${label} ${size}`}>
+      <Text style={styles.label} accessibilityElementsHidden={true}>{label}</Text>
+      <Text style={styles.value} accessibilityElementsHidden={true}>{size}</Text>
     </View>
   );
 };

--- a/app/src/components/ImageModal.tsx
+++ b/app/src/components/ImageModal.tsx
@@ -108,9 +108,11 @@ const ImageModal: React.FC<ImageModalProps> = ({uri, visible, onClose}) => {
   }
 
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={handleClose}>
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={handleClose} accessibilityViewIsModal={true}>
       <View style={styles.overlay}>
-        <TouchableOpacity style={styles.closeBtn} onPress={handleClose}>
+        <TouchableOpacity style={styles.closeBtn} onPress={handleClose}
+          accessibilityRole="button"
+          accessibilityLabel={t('close')}>
           <Text style={styles.closeBtnText}>✕</Text>
         </TouchableOpacity>
         <Animated.Image
@@ -122,9 +124,14 @@ const ImageModal: React.FC<ImageModalProps> = ({uri, visible, onClose}) => {
             },
           ]}
           resizeMode="contain"
+          accessible={true}
+          accessibilityRole="image"
+          accessibilityLabel={t('previewImage')}
           {...panResponder.panHandlers}
         />
-        <TouchableOpacity style={styles.resetBtn} onPress={reset}>
+        <TouchableOpacity style={styles.resetBtn} onPress={reset}
+          accessibilityRole="button"
+          accessibilityLabel={t('reset')}>
           <Text style={styles.resetBtnText}>{t('reset')}</Text>
         </TouchableOpacity>
       </View>

--- a/app/src/components/ImagePicker.tsx
+++ b/app/src/components/ImagePicker.tsx
@@ -51,7 +51,15 @@ const ImagePicker: React.FC<ImagePickerProps> = ({
     <TouchableOpacity
       style={[styles.button, selectedImage && styles.buttonSelected]}
       onPress={handlePress}
-      activeOpacity={0.7}>
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={
+        selectedImage
+          ? isVideo
+            ? t('changeVideo')
+            : t('changeImage')
+          : t('pickImageOrVideo')
+      }>
       <Text style={styles.icon}>{isVideo ? '🎬' : '🖼️'}</Text>
       <Text style={styles.buttonText}>
         {selectedImage

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -22,6 +22,7 @@ const DICT: Dict = {
   width: {ja: '幅', en: 'Width'},
   height: {ja: '高さ', en: 'Height'},
   reset: {ja: 'リセット', en: 'Reset'},
+  previewImage: {ja: 'プレビュー画像', en: 'Preview image'},
   noConversionNeededTitle: {ja: '変換不要', en: 'No conversion needed'},
   noConversionNeededMessage: {ja: '現在の設定では変換の必要がありません。\nフォーマットやリサイズを変更してください。', en: 'No conversion is needed with the current settings.\nPlease change the format or resize settings.'},
   convertFailed: {ja: '変換に失敗しました', en: 'Conversion failed'},


### PR DESCRIPTION
## 概要
closes #99

## 変更内容

### ErrorModal.tsx
- `Modal` に `accessibilityViewIsModal={true}` を追加
- タイトル `Text` に `accessibilityRole="header"` を追加
- コピーボタンに `accessibilityRole="button"`、`accessibilityLabel` を追加
- 閉じるボタンに `accessibilityRole="button"`、`accessibilityLabel` を追加

### ImageModal.tsx
- `Modal` に `accessibilityViewIsModal={true}` を追加
- 閉じるボタンに `accessibilityRole="button"`、`accessibilityLabel` を追加
- `Animated.Image` に `accessible={true}`、`accessibilityRole="image"`、`accessibilityLabel` を追加
- リセットボタンに `accessibilityRole="button"`、`accessibilityLabel` を追加

### ImagePicker.tsx
- `TouchableOpacity` に `accessibilityRole="button"`、状態に応じた `accessibilityLabel` を追加

### FileSizeLabel.tsx
- 外側 `View` を `accessible={true}` にして `accessibilityLabel` でラベルとサイズを結合
- 子の `Text` に `accessibilityElementsHidden={true}` を追加（スクリーンリーダーの重複読み上げ防止）

### i18n.ts
- `previewImage` キーを追加（ja: 'プレビュー画像' / en: 'Preview image'）