### PR TITLE
a11y: ResizeSlider タブボタンにアクセシビリティ属性を追加 (#101)

### DIFF
--- a/app/src/components/ResizeSlider.tsx
+++ b/app/src/components/ResizeSlider.tsx
@@ -60,14 +60,20 @@ const ResizeSlider: React.FC<ResizeSliderProps> = ({value, onValueChange, origin
         <TouchableOpacity
           style={[styles.tab, activeTab === 'percent' && styles.tabActive]}
           onPress={() => setActiveTab('percent')}
-          activeOpacity={0.7}>
+          activeOpacity={0.7}
+          accessibilityRole="tab"
+          accessibilityLabel={t('resizePercentTab')}
+          accessibilityState={{selected: activeTab === 'percent'}}>
           <Text style={[styles.tabText, activeTab === 'percent' && styles.tabTextActive]}>{t('resizePercentTab')}</Text>
         </TouchableOpacity>
         {hasOriginal && (
           <TouchableOpacity
             style={[styles.tab, activeTab === 'resolution' && styles.tabActive]}
             onPress={() => setActiveTab('resolution')}
-            activeOpacity={0.7}>
+            activeOpacity={0.7}
+            accessibilityRole="tab"
+            accessibilityLabel={t('resizeResolutionTab')}
+            accessibilityState={{selected: activeTab === 'resolution'}}>
             <Text style={[styles.tabText, activeTab === 'resolution' && styles.tabTextActive]}>{t('resizeResolutionTab')}</Text>
           </TouchableOpacity>
         )}


### PR DESCRIPTION
## 概要
closes #101

## 変更内容

### ResizeSlider.tsx
- percent タブの `TouchableOpacity` に `accessibilityRole="tab"`、`accessibilityLabel`（t('resizePercentTab')）、`accessibilityState={{selected: activeTab === 'percent'}}` を追加
- resolution タブの `TouchableOpacity` に `accessibilityRole="tab"`、`accessibilityLabel`（t('resizeResolutionTab')）、`accessibilityState={{selected: activeTab === 'resolution'}}` を追加

これによりスクリーンリーダーが各タブをタブコントロールとして認識し、選択状態も読み上げられるようになります。