### PR TITLE
a11y: MainScreen Aboutボタン・変換方式タブにアクセシビリティ属性を追加

### DIFF
--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -52,6 +52,7 @@ const DICT: Dict = {
   showAfterConversion: {ja: '変換後に表示', en: 'Shown after conversion'},
   setParameters: {ja: 'パラメータを設定する', en: 'Set parameters'},
   setTargetSize: {ja: '目標サイズを指定する', en: 'Set target size'},
+  aboutButton: {ja: 'アプリ情報', en: 'About this app'},
   template: {ja: 'テンプレート', en: 'Template'},
   gabigabiLevel: {ja: 'ガビガビレベル', en: 'Blocky level'},
   outputFormat: {ja: '出力フォーマット', en: 'Output format'},

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -640,6 +640,8 @@ const MainScreen = () => {
           <TouchableOpacity
             onPress={() => setAboutVisible(true)}
             style={styles.aboutButton}
+            accessibilityRole="button"
+            accessibilityLabel={t('aboutButton')}
           >
             <Text style={styles.aboutButtonIcon}>ℹ️</Text>
           </TouchableOpacity>
@@ -698,12 +700,18 @@ const MainScreen = () => {
         <View style={styles.methodTabs}>
           <TouchableOpacity
             style={[styles.methodTab, convertMethod === 'parameters' && styles.methodTabActive]}
-            onPress={() => setConvertMethod('parameters')}>
+            onPress={() => setConvertMethod('parameters')}
+            accessibilityRole="tab"
+            accessibilityLabel={t('setParameters')}
+            accessibilityState={{selected: convertMethod === 'parameters'}}>
             <Text style={[styles.methodTabText, convertMethod === 'parameters' && styles.methodTabTextActive]}>{t('setParameters')}</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={[styles.methodTab, convertMethod === 'targetSize' && styles.methodTabActive]}
-            onPress={() => setConvertMethod('targetSize')}>
+            onPress={() => setConvertMethod('targetSize')}
+            accessibilityRole="tab"
+            accessibilityLabel={t('setTargetSize')}
+            accessibilityState={{selected: convertMethod === 'targetSize'}}>
             <Text style={[styles.methodTabText, convertMethod === 'targetSize' && styles.methodTabTextActive]}>{t('setTargetSize')}</Text>
           </TouchableOpacity>
         </View>


### PR DESCRIPTION
## 対応issue
- closes #105
- closes #106

## 変更内容

### #105: Aboutボタンにアクセシビリティ属性を追加
- `accessibilityRole="button"` を追加
- `accessibilityLabel={t('aboutButton')}` を追加
- i18n.ts に `aboutButton: {ja: 'アプリ情報', en: 'About this app'}` を追加

### #106: 変換方式タブにアクセシビリティ属性を追加
- 「パラメータを設定する」「目標サイズを指定する」タブに `accessibilityRole="tab"` を追加
- `accessibilityLabel` で各タブのラベルを明示
- `accessibilityState={{selected: ...}}` で選択状態をスクリーンリーダーに伝える