### PR TITLE
test: conversionHistory.test.ts に clearConversionHistory のテストを追加

### DIFF
--- a/app/src/__tests__/conversionHistory.test.ts
+++ b/app/src/__tests__/conversionHistory.test.ts
@@ -1,14 +1,16 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import {getConversionHistory, saveConversionHistoryItem} from '../data/history/conversionHistory';
+import {getConversionHistory, saveConversionHistoryItem, clearConversionHistory} from '../data/history/conversionHistory';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
   setItem: jest.fn(),
+  removeItem: jest.fn(),
 }));
 
 const mockedAsyncStorage = AsyncStorage as unknown as {
   getItem: jest.Mock;
   setItem: jest.Mock;
+  removeItem: jest.Mock;
 };
 
 describe('conversionHistory', () => {
@@ -24,6 +26,20 @@ describe('conversionHistory', () => {
 
   it('履歴が壊れていたら空配列を返す', async () => {
     mockedAsyncStorage.getItem.mockResolvedValueOnce('{broken');
+    const rows = await getConversionHistory();
+    expect(rows).toEqual([]);
+  });
+
+  it('clearConversionHistory を呼ぶと removeItem が正しいキーで呼ばれる', async () => {
+    mockedAsyncStorage.removeItem.mockResolvedValueOnce(undefined);
+    await clearConversionHistory();
+    expect(mockedAsyncStorage.removeItem).toHaveBeenCalledWith('conversion-history-v1');
+  });
+
+  it('clearConversionHistory 後に getConversionHistory が空配列を返す', async () => {
+    mockedAsyncStorage.removeItem.mockResolvedValueOnce(undefined);
+    mockedAsyncStorage.getItem.mockResolvedValueOnce(null);
+    await clearConversionHistory();
     const rows = await getConversionHistory();
     expect(rows).toEqual([]);
   });


### PR DESCRIPTION
Closes #112

## 変更内容

- `clearConversionHistory()` を呼ぶと `AsyncStorage.removeItem` が `'conversion-history-v1'` キーで呼ばれることを検証
- `clearConversionHistory()` 後に `getConversionHistory()` が空配列を返すことを検証
- `AsyncStorage` モックに `removeItem` を追加