### PR TITLE
a11y: ConversionHistoryModal に不足しているアクセシビリティ属性を追加

### DIFF
--- a/app/src/screens/components/ConversionHistoryModal.tsx
+++ b/app/src/screens/components/ConversionHistoryModal.tsx
@@ -62,9 +62,10 @@ const HistoryItem: React.FC<{item: ConversionHistoryItem}> = ({item}) => {
     ? Math.round((item.outputBytes / item.inputBytes) * 100)
     : 0;
   const fileName = item.outputPath.split('/').pop() ?? '—';
+  const a11yLabel = `${actionLabel(item.params.action)} ${formatDate(item.createdAt)} ${formatBytes(item.inputBytes)} → ${formatBytes(item.outputBytes)} (${ratio}%)`;
 
   return (
-    <View style={styles.itemCard}>
+    <View style={styles.itemCard} accessible={true} accessibilityLabel={a11yLabel}>
       <View style={styles.itemHeader}>
         <Text style={styles.itemDate}>{formatDate(item.createdAt)}</Text>
         <View style={[styles.actionBadge, item.params.action === 'gabigabi' && styles.actionBadgeGabi]}>
@@ -128,7 +129,11 @@ const ConversionHistoryModal: React.FC<ConversionHistoryModalProps> = ({visible,
         {/* Header */}
         <View style={styles.header}>
           <Text style={styles.headerTitle}>{t('conversionHistoryTitle')}</Text>
-          <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+          <TouchableOpacity
+            onPress={onClose}
+            style={styles.closeButton}
+            accessibilityRole="button"
+            accessibilityLabel={t('close')}>
             <Text style={styles.closeButtonText}>{t('close')}</Text>
           </TouchableOpacity>
         </View>
@@ -149,6 +154,8 @@ const ConversionHistoryModal: React.FC<ConversionHistoryModalProps> = ({visible,
             renderItem={({item}) => <HistoryItem item={item} />}
             contentContainerStyle={styles.listContent}
             showsVerticalScrollIndicator={false}
+            accessible={true}
+            accessibilityLabel={t('conversionHistoryTitle')}
           />
         )}
 


### PR DESCRIPTION
Closes #111

## 変更内容

- 閉じるボタン（TouchableOpacity）に `accessibilityRole="button"`、`accessibilityLabel={t('close')}` を追加
- FlatList に `accessible={true}`、`accessibilityLabel={t('conversionHistoryTitle')}` を追加
- HistoryItem の各カード（View）に `accessible={true}`、変換アクション・日時・サイズをまとめた `accessibilityLabel` を追加