### PR TITLE
refactor: formatBytes 関数を共有ユーティリティに統合する

### DIFF
--- a/app/src/components/FileSizeLabel.tsx
+++ b/app/src/components/FileSizeLabel.tsx
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 import * as FileSystem from 'expo-file-system';
 import { getFileSizeBytes } from '../data/ffmpeg/ffmpegUtils';
+import { formatBytes } from '../utils/formatBytes';
 
 interface FileSizeLabelProps {
   label: string;
@@ -10,16 +11,6 @@ interface FileSizeLabelProps {
 
 const TEXT_SECONDARY = '#888';
 const ACCENT2 = '#fc913a';
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) {
-    return `${bytes} B`;
-  }
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`;
-  }
-  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
-}
 
 const FileSizeLabel: React.FC<FileSizeLabelProps> = ({label, uri}) => {
   const [size, setSize] = useState<string | null>(null);

--- a/app/src/domain/convertImage.ts
+++ b/app/src/domain/convertImage.ts
@@ -1,4 +1,5 @@
 import { convertImage as ffmpegConvertImage, ImageFormat, ConvertOptions, FfmpegConvertResult } from '../data/ffmpeg/FfmpegConverter';
+export { formatBytes } from '../utils/formatBytes';
 
 export type { ImageFormat };
 
@@ -27,11 +28,4 @@ export async function convertImage(
   };
 }
 
-/**
- * ファイルサイズを人間が読みやすい文字列に変換する。
- */
-export function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
-}
+

--- a/app/src/utils/formatBytes.ts
+++ b/app/src/utils/formatBytes.ts
@@ -1,0 +1,8 @@
+/**
+ * ファイルサイズを人間が読みやすい文字列に変換する共通ユーティリティ。
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}


### PR DESCRIPTION
Closes #116\n\n## 変更内容\n- `app/src/utils/formatBytes.ts` を新規作成し共通関数を定義\n- `FileSizeLabel.tsx` のインライン実装を削除し共通関数をインポート\n- `convertImage.ts` の実装を削除し re-export に変更\n- DRY 原則に対応