### PR TITLE
fix: 処理中に画像ピッカーを開けてしまう問題を修正する（isProcessing ガード追加）

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -243,6 +243,7 @@ const MainScreen = () => {
   );
 
   const handleOpenPicker = useCallback(async () => {
+    if (isProcessing) return;
     const { status } = await ExpoImagePicker.requestMediaLibraryPermissionsAsync();
     if (status !== 'granted') {
       Alert.alert(t('permissionRequired'), t('galleryPermissionMessage'));
@@ -260,7 +261,7 @@ const MainScreen = () => {
         /\.(mp4|mov|mkv|webm|m4v|3gp|flv)$/i.test(asset.uri);
       handleImageSelect(asset.uri, isVideo ? 'video' : 'image');
     }
-  }, [handleImageSelect]);
+  }, [handleImageSelect, isProcessing]);
 
   const handleResizeChange = useCallback(
     (percent: number) => {


### PR DESCRIPTION
## 概要\n\nClose #122\n\n の先頭に  チェックを追加し、変換処理中は画像ピッカーが開かないよう修正しました。\n\n## 変更内容\n\n- :  の先頭に  を追加\n-  の依存配列に  を追加