### PR TITLE
fix: handleImageSelect の useCallback 依存配列に setSelectedMediaType を追加する

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -239,7 +239,7 @@ const MainScreen = () => {
       setSelectedMediaType(mediaType);
       setProcessedImage(null);
     },
-    [setSelectedImage, setProcessedImage],
+    [setSelectedImage, setSelectedMediaType, setProcessedImage],
   );
 
   const handleOpenPicker = useCallback(async () => {


### PR DESCRIPTION
Close #123

handleImageSelect の useCallback 依存配列に setSelectedMediaType が漏れていたため追加しました。