### PR TITLE
refactor: ローカルカラー定数を sharedStyles からインポートするよう統一する

### DIFF
--- a/app/src/components/ErrorModal.tsx
+++ b/app/src/components/ErrorModal.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import {t} from '../i18n';
+import {DARK_BG, CARD_BG, ACCENT, TEXT_PRIMARY, TEXT_SECONDARY, BORDER} from '../screens/components/sharedStyles';
 
 interface ErrorModalProps {
   visible: boolean;
@@ -16,13 +17,6 @@ interface ErrorModalProps {
   message: string;
   onClose: () => void;
 }
-
-const DARK_BG = '#0d0d0d';
-const CARD_BG = '#1a1a1a';
-const ACCENT = '#ff4e50';
-const TEXT_PRIMARY = '#f0f0f0';
-const TEXT_SECONDARY = '#888';
-const BORDER = '#2a2a2a';
 
 const ErrorModal: React.FC<ErrorModalProps> = ({
   visible,

--- a/app/src/components/FileSizeLabel.tsx
+++ b/app/src/components/FileSizeLabel.tsx
@@ -3,14 +3,12 @@ import {View, Text, StyleSheet} from 'react-native';
 import * as FileSystem from 'expo-file-system';
 import { getFileSizeBytes } from '../data/ffmpeg/ffmpegUtils';
 import { formatBytes } from '../utils/formatBytes';
+import { TEXT_SECONDARY, ACCENT2 } from '../screens/components/sharedStyles';
 
 interface FileSizeLabelProps {
   label: string;
   uri: string;
 }
-
-const TEXT_SECONDARY = '#888';
-const ACCENT2 = '#fc913a';
 
 const FileSizeLabel: React.FC<FileSizeLabelProps> = ({label, uri}) => {
   const [size, setSize] = useState<string | null>(null);

--- a/app/src/components/ImagePicker.tsx
+++ b/app/src/components/ImagePicker.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {View, TouchableOpacity, Text, StyleSheet, Alert} from 'react-native';
 import * as ExpoImagePicker from 'expo-image-picker';
 import {t} from '../i18n';
+import {ACCENT, CARD_BG, BORDER, TEXT_SECONDARY} from '../screens/components/sharedStyles';
 
 interface ImagePickerProps {
   onImageSelect: (imageUri: string, mediaType: 'image' | 'video') => void;
@@ -14,11 +15,6 @@ const resolvePickerMediaTypes = (selectedMediaType?: 'image' | 'video') => {
   if (selectedMediaType === 'image') return ['images'] as const;
   return ['images', 'videos'] as const;
 };
-
-const ACCENT = '#ff4e50';
-const CARD_BG = '#1a1a1a';
-const BORDER = '#2a2a2a';
-const TEXT_SECONDARY = '#888';
 
 const ImagePicker: React.FC<ImagePickerProps> = ({
   onImageSelect,

--- a/app/src/screens/components/ConversionHistoryModal.tsx
+++ b/app/src/screens/components/ConversionHistoryModal.tsx
@@ -16,24 +16,14 @@ import {
 } from '../../data/history/conversionHistory';
 import {t} from '../../i18n';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {DARK_BG, CARD_BG, ACCENT, TEXT_PRIMARY, TEXT_SECONDARY, BORDER} from './sharedStyles';
+import {formatBytes} from '../../utils/formatBytes';
 
 interface ConversionHistoryModalProps {
   visible: boolean;
   onClose: () => void;
 }
 
-const DARK_BG = '#0d0d0d';
-const CARD_BG = '#1a1a1a';
-const ACCENT = '#ff4e50';
-const TEXT_PRIMARY = '#f0f0f0';
-const TEXT_SECONDARY = '#888';
-const BORDER = '#2a2a2a';
-
-function formatBytes(bytes: number): string {
-  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
-  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${bytes} B`;
-}
 
 function formatDate(iso: string): string {
   try {

--- a/app/src/screens/components/ImageInfoBlock.tsx
+++ b/app/src/screens/components/ImageInfoBlock.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {View, Text, StyleSheet} from 'react-native';
-import {CARD_BG} from './sharedStyles';
+import {CARD_BG, TEXT_SECONDARY} from './sharedStyles';
 
 interface FileInfo {
   name: string;
@@ -22,7 +22,6 @@ interface AfterInfoBlockProps {
   showAfterConversion: string;
 }
 
-const TEXT_SECONDARY = '#aaa';
 const styles = StyleSheet.create({
   infoBlock: {
     backgroundColor: CARD_BG,


### PR DESCRIPTION
## 概要

Closes #128

ローカルに定義されていたカラー定数を `sharedStyles` からのインポートに統一した。

## 変更内容

| ファイル | 削除した定数 | 備考 |
|---|---|---|
| `ErrorModal.tsx` | `DARK_BG`, `CARD_BG`, `ACCENT`, `TEXT_PRIMARY`, `TEXT_SECONDARY`, `BORDER` | |
| `ImagePicker.tsx` | `ACCENT`, `CARD_BG`, `BORDER`, `TEXT_SECONDARY` | |
| `FileSizeLabel.tsx` | `TEXT_SECONDARY`, `ACCENT2` | |
| `ConversionHistoryModal.tsx` | 全ローカルカラー定数 + ローカル `formatBytes` 関数 | `formatBytes` を `utils/formatBytes` に置き換え |
| `ImageInfoBlock.tsx` | `TEXT_SECONDARY`（旧値 `#aaa`） | `sharedStyles` の `#888` に統一 |