### PR TITLE
feat: 変換履歴アイテムにサムネイル画像を表示する

### DIFF
--- a/app/src/__tests__/ConversionHistoryModal.test.tsx
+++ b/app/src/__tests__/ConversionHistoryModal.test.tsx
@@ -15,6 +15,11 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   removeItem: jest.fn(),
 }));
 
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({top: 0, bottom: 0, left: 0, right: 0}),
+  SafeAreaProvider: ({children}: {children: React.ReactNode}) => children,
+}));
+
 jest.mock('../data/history/conversionHistory', () => ({
   getConversionHistory: jest.fn(),
   clearConversionHistory: jest.fn(),
@@ -101,6 +106,17 @@ describe('ConversionHistoryModal', () => {
     const renderer = await createWithData([sampleItem]);
     const json = JSON.stringify(renderer.toJSON());
     expect(json).toContain('sample_out.jpg');
+  });
+
+  it('サムネイル画像が正しいURIでレンダリングされる', async () => {
+    const renderer = await createWithData([sampleItem]);
+    const images = renderer.root.findAll(
+      (node: ReactTestRenderer.ReactTestInstance) =>
+        node.type === 'Image' &&
+        node.props.accessibilityLabel === '変換後画像のサムネイル',
+    );
+    expect(images.length).toBeGreaterThan(0);
+    expect(images[0].props.source.uri).toBe('file:///out/sample_out.jpg');
   });
 
   it('「クリア」ボタンは履歴ありのときのみ表示される', async () => {

--- a/app/src/screens/components/ConversionHistoryModal.tsx
+++ b/app/src/screens/components/ConversionHistoryModal.tsx
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   Alert,
   ActivityIndicator,
+  Image,
 } from 'react-native';
 import {
   ConversionHistoryItem,
@@ -48,29 +49,54 @@ function actionLabel(action: ConversionHistoryItem['params']['action']): string 
   }
 }
 
+const HistoryItemThumbnail: React.FC<{uri: string}> = ({uri}) => {
+  const [error, setError] = useState(false);
+  if (error) {
+    return (
+      <View style={styles.thumbnail} accessibilityLabel="変換後画像のサムネイル">
+        <Text style={styles.thumbnailFallback}>📷</Text>
+      </View>
+    );
+  }
+  return (
+    <Image
+      source={{uri}}
+      style={styles.thumbnail}
+      accessibilityLabel="変換後画像のサムネイル"
+      onError={() => setError(true)}
+    />
+  );
+};
+
 const HistoryItem: React.FC<{item: ConversionHistoryItem}> = ({item}) => {
   const ratio = item.inputBytes > 0
     ? Math.round((item.outputBytes / item.inputBytes) * 100)
     : 0;
   const fileName = item.outputPath.split('/').pop() ?? '—';
   const a11yLabel = `${actionLabel(item.params.action)} ${formatDate(item.createdAt)} ${formatBytes(item.inputBytes)} → ${formatBytes(item.outputBytes)} (${ratio}%)`;
+  const thumbnailUri = item.outputPath.startsWith('file://') ? item.outputPath : `file://${item.outputPath}`;
 
   return (
     <View style={styles.itemCard} accessible={true} accessibilityLabel={a11yLabel}>
-      <View style={styles.itemHeader}>
-        <Text style={styles.itemDate}>{formatDate(item.createdAt)}</Text>
-        <View style={[styles.actionBadge, item.params.action === 'gabigabi' && styles.actionBadgeGabi]}>
-          <Text style={styles.actionBadgeText}>{actionLabel(item.params.action)}</Text>
+      <View style={styles.itemRow}>
+        <HistoryItemThumbnail uri={thumbnailUri} />
+        <View style={styles.itemContent}>
+          <View style={styles.itemHeader}>
+            <Text style={styles.itemDate}>{formatDate(item.createdAt)}</Text>
+            <View style={[styles.actionBadge, item.params.action === 'gabigabi' && styles.actionBadgeGabi]}>
+              <Text style={styles.actionBadgeText}>{actionLabel(item.params.action)}</Text>
+            </View>
+          </View>
+          <Text style={styles.itemFileName} numberOfLines={1} ellipsizeMode="middle">📄 {fileName}</Text>
+          <View style={styles.itemSizeRow}>
+            <Text style={styles.itemSize}>{formatBytes(item.inputBytes)}</Text>
+            <Text style={styles.itemArrow}>→</Text>
+            <Text style={[styles.itemSize, ratio < 100 ? styles.sizeReduced : styles.sizeIncreased]}>
+              {formatBytes(item.outputBytes)}
+            </Text>
+            <Text style={styles.itemRatio}>({ratio}%)</Text>
+          </View>
         </View>
-      </View>
-      <Text style={styles.itemFileName} numberOfLines={1} ellipsizeMode="middle">📄 {fileName}</Text>
-      <View style={styles.itemSizeRow}>
-        <Text style={styles.itemSize}>{formatBytes(item.inputBytes)}</Text>
-        <Text style={styles.itemArrow}>→</Text>
-        <Text style={[styles.itemSize, ratio < 100 ? styles.sizeReduced : styles.sizeIncreased]}>
-          {formatBytes(item.outputBytes)}
-        </Text>
-        <Text style={styles.itemRatio}>({ratio}%)</Text>
       </View>
     </View>
   );
@@ -219,6 +245,27 @@ const styles = StyleSheet.create({
     borderColor: BORDER,
     padding: 14,
     marginBottom: 10,
+    gap: 6,
+  },
+  itemRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+  },
+  thumbnail: {
+    width: 48,
+    height: 48,
+    borderRadius: 8,
+    backgroundColor: '#333',
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+    flexShrink: 0,
+  },
+  thumbnailFallback: {
+    fontSize: 24,
+  },
+  itemContent: {
+    flex: 1,
     gap: 6,
   },
   itemHeader: {


### PR DESCRIPTION
## 概要

Closes #132

変換履歴モーダルの各アイテム左端に、変換後画像のサムネイル（48×48px）を表示する。

## 変更内容

- `HistoryItemThumbnail` コンポーネントを新規追加
  - `outputPath` をURIとして `<Image>` でレンダリング
  - 画像ロードエラー時は📷アイコンにフォールバック
  - `accessibilityLabel="変換後画像のサムネイル"` を設定
- `HistoryItem` のレイアウトを横並び（Row）に変更し、サムネイルと情報を並列表示
- テストに `react-native-safe-area-context` モックを追加して全テストを修正
- サムネイルURIの正確性を検証するテストケースを追加