### PR TITLE
feat: GIF変換時のFPS・スケール設定をUIに追加する (#138)

### DIFF
--- a/app/src/__tests__/useAppStore.test.ts
+++ b/app/src/__tests__/useAppStore.test.ts
@@ -40,6 +40,8 @@ describe('useAppStore', () => {
       convertMethod: 'parameters',
       targetSizeValue: '10',
       targetSizeUnit: 'MB',
+      gifFps: 10,
+      gifScale: 100,
     });
   });
 
@@ -275,6 +277,43 @@ describe('useAppStore', () => {
     it('"GB" をセットできる', () => {
       useAppStore.getState().setTargetSizeUnit('GB');
       expect(useAppStore.getState().targetSizeUnit).toBe('GB');
+    });
+  });
+
+  describe('setGifFps', () => {
+    it('gifFps のデフォルト値は 10', () => {
+      expect(useAppStore.getState().gifFps).toBe(10);
+    });
+
+    it('gifFps を正しく更新する', () => {
+      useAppStore.getState().setGifFps(15);
+      expect(useAppStore.getState().gifFps).toBe(15);
+    });
+
+    it('gifFps を 1 にセットできる', () => {
+      useAppStore.getState().setGifFps(1);
+      expect(useAppStore.getState().gifFps).toBe(1);
+    });
+
+    it('gifFps を 30 にセットできる', () => {
+      useAppStore.getState().setGifFps(30);
+      expect(useAppStore.getState().gifFps).toBe(30);
+    });
+  });
+
+  describe('setGifScale', () => {
+    it('gifScale のデフォルト値は 100', () => {
+      expect(useAppStore.getState().gifScale).toBe(100);
+    });
+
+    it('gifScale を正しく更新する', () => {
+      useAppStore.getState().setGifScale(50);
+      expect(useAppStore.getState().gifScale).toBe(50);
+    });
+
+    it('gifScale を 1 にセットできる', () => {
+      useAppStore.getState().setGifScale(1);
+      expect(useAppStore.getState().gifScale).toBe(1);
     });
   });
 

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -94,6 +94,10 @@ const DICT: Dict = {
   actionGabigabi: {ja: 'ガビガビ化', en: 'Blocky'},
   actionConvert: {ja: '変換', en: 'Convert'},
   actionTargetSize: {ja: 'サイズ指定', en: 'Target size'},
+  gifFps: {ja: 'GIF フレームレート', en: 'GIF Frame Rate'},
+  gifFpsSlider: {ja: 'GIF フレームレートスライダー', en: 'GIF frame rate slider'},
+  gifScale: {ja: 'GIF スケール率', en: 'GIF Scale'},
+  gifScaleSlider: {ja: 'GIF スケール率スライダー', en: 'GIF scale slider'},
 };
 
 export const t = (key: keyof typeof DICT): string => {

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -84,6 +84,8 @@ const MainScreen = () => {
     convertMethod,
     targetSizeValue,
     targetSizeUnit,
+    gifFps,
+    gifScale,
     setSelectedImage,
     setSelectedMediaType,
     setResizePercent,
@@ -100,6 +102,8 @@ const MainScreen = () => {
     setConvertMethod,
     setTargetSizeValue,
     setTargetSizeUnit,
+    setGifFps,
+    setGifScale,
   } = useAppStore();
 
   const [errorModal, setErrorModal] = useState<{visible: boolean; title: string; message: string}>({
@@ -477,6 +481,7 @@ const MainScreen = () => {
             const result = await convertImage(selectedImage, {
               outputFormat,
               quality: compressionRate,
+              ...(outputFormat === 'gif' ? {gifFps, gifScale} : {}),
             });
             resultUri = result.outputUri;
             resultBytes = result.outputBytes;
@@ -754,6 +759,10 @@ const MainScreen = () => {
             onShrinkExpandRateChange={handleShrinkExpandRateChange}
             onMultiCompressToggle={handleMultiCompressToggle}
             onMultiCompressCountChange={handleMultiCompressCountChange}
+            gifFps={gifFps}
+            gifScale={gifScale}
+            onGifFpsChange={setGifFps}
+            onGifScaleChange={setGifScale}
           />
         ) : (
           <TargetSizePanel

--- a/app/src/screens/components/SettingsPanel.tsx
+++ b/app/src/screens/components/SettingsPanel.tsx
@@ -48,6 +48,8 @@ interface SettingsPanelProps {
   multiCompressCount: number;
   fileInfoWidth?: number;
   fileInfoHeight?: number;
+  gifFps: number;
+  gifScale: number;
   onTemplateSelect: (level: number) => void;
   onResizeChange: (percent: number) => void;
   onQualityChange: (quality: number) => void;
@@ -57,6 +59,8 @@ interface SettingsPanelProps {
   onShrinkExpandRateChange: (val: number) => void;
   onMultiCompressToggle: (val: boolean) => void;
   onMultiCompressCountChange: (val: number) => void;
+  onGifFpsChange: (fps: number) => void;
+  onGifScaleChange: (scale: number) => void;
 }
 
 const SettingsPanel: React.FC<SettingsPanelProps> = ({
@@ -72,6 +76,8 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
   multiCompressCount,
   fileInfoWidth,
   fileInfoHeight,
+  gifFps,
+  gifScale,
   onTemplateSelect,
   onResizeChange,
   onQualityChange,
@@ -81,6 +87,8 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
   onShrinkExpandRateChange,
   onMultiCompressToggle,
   onMultiCompressCountChange,
+  onGifFpsChange,
+  onGifScaleChange,
 }) => (
   <>
     {/* ── Template Section ── */}
@@ -178,6 +186,46 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
         </>
       )}
 
+      {selectedMediaType !== 'video' && outputFormat === 'gif' && (
+        <>
+          <View style={sharedStyles.qualityRow}>
+            <View style={sharedStyles.qualityLabelRow}>
+              <Text style={sharedStyles.qualityLabel}>{t('gifFps')}</Text>
+              <Text style={sharedStyles.qualityValue}>{gifFps} fps</Text>
+            </View>
+            <CustomSlider
+              style={sharedStyles.qualitySlider}
+              minimumValue={1}
+              maximumValue={30}
+              step={1}
+              value={gifFps}
+              onValueChange={(v: number) => onGifFpsChange(Math.round(v))}
+              accessibilityLabel={t('gifFpsSlider')}
+              minimumTrackTintColor={ACCENT2}
+              maximumTrackTintColor={BORDER}
+              thumbTintColor={ACCENT2}
+            />
+          </View>
+          <View style={sharedStyles.qualityRow}>
+            <View style={sharedStyles.qualityLabelRow}>
+              <Text style={sharedStyles.qualityLabel}>{t('gifScale')}</Text>
+              <Text style={sharedStyles.qualityValue}>{gifScale}%</Text>
+            </View>
+            <CustomSlider
+              style={sharedStyles.qualitySlider}
+              minimumValue={1}
+              maximumValue={100}
+              step={1}
+              value={gifScale}
+              onValueChange={(v: number) => onGifScaleChange(Math.round(v))}
+              accessibilityLabel={t('gifScaleSlider')}
+              minimumTrackTintColor={ACCENT2}
+              maximumTrackTintColor={BORDER}
+              thumbTintColor={ACCENT2}
+            />
+          </View>
+        </>
+      )}
       {((selectedMediaType !== 'video' && (outputFormat === 'jpeg' || outputFormat === 'webp')) || selectedMediaType === 'video') && (
         <View style={sharedStyles.qualityRow}>
           <View style={sharedStyles.qualityLabelRow}>

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -25,6 +25,9 @@ interface AppState {
   convertMethod: ConvertMethod;
   targetSizeValue: string;
   targetSizeUnit: SizeUnit;
+  // #138 GIF options
+  gifFps: number;
+  gifScale: number;
   
   setSelectedImage: (image: string | null) => void;
   setSelectedMediaType: (mediaType: 'image' | 'video' | null) => void;
@@ -43,6 +46,9 @@ interface AppState {
   setConvertMethod: (method: ConvertMethod) => void;
   setTargetSizeValue: (value: string) => void;
   setTargetSizeUnit: (unit: SizeUnit) => void;
+  // #138 GIF setters
+  setGifFps: (fps: number) => void;
+  setGifScale: (scale: number) => void;
 }
 
 export const useAppStore = create<AppState>()(
@@ -64,6 +70,8 @@ export const useAppStore = create<AppState>()(
       convertMethod: 'parameters',
       targetSizeValue: '10',
       targetSizeUnit: 'MB',
+      gifFps: 10,
+      gifScale: 100,
 
       setSelectedImage: image => set({selectedImage: image}),
       setSelectedMediaType: mediaType => set({selectedMediaType: mediaType}),
@@ -81,6 +89,8 @@ export const useAppStore = create<AppState>()(
       setConvertMethod: method => set({convertMethod: method}),
       setTargetSizeValue: value => set({targetSizeValue: value}),
       setTargetSizeUnit: unit => set({targetSizeUnit: unit}),
+      setGifFps: fps => set({gifFps: fps}),
+      setGifScale: scale => set({gifScale: scale}),
     }),
     {
       name: 'gabigabi-app-settings',
@@ -97,6 +107,8 @@ export const useAppStore = create<AppState>()(
         convertMethod: state.convertMethod,
         targetSizeValue: state.targetSizeValue,
         targetSizeUnit: state.targetSizeUnit,
+        gifFps: state.gifFps,
+        gifScale: state.gifScale,
       }),
     },
   ),


### PR DESCRIPTION
## 概要

Issue #138 の実装。GIF変換時にFPSとスケール率をUIから設定できるようにする。

## 変更内容

- **store.ts**: `gifFps`（デフォルト10）と `gifScale`（デフォルト100）フィールド・setterを追加、AsyncStorage永続化対象にも追加
- **SettingsPanel.tsx**: GIF出力フォーマット選択時のみ、FPSスライダー（1〜30）とスケール率スライダー（1〜100%）を条件付きレンダリング
- **MainScreen.tsx**: `convertImage` 呼び出し時にGIF選択時は `gifFps`・`gifScale` を渡すよう修正
- **i18n.ts**: `gifFps`, `gifFpsSlider`, `gifScale`, `gifScaleSlider` キーを追加（日本語・英語）
- **useAppStore.test.ts**: gifFps/gifScale のデフォルト値・setter テストを追加

## テスト

- `setGifFps` / `setGifScale` のユニットテストを useAppStore.test.ts に追加

Closes #138