### PR TITLE
feat: X(Twitter)・LINE・Instagram のターゲットサイズプリセットを追加する

### DIFF
--- a/app/src/screens/components/TargetSizePanel.tsx
+++ b/app/src/screens/components/TargetSizePanel.tsx
@@ -6,6 +6,9 @@ import {sharedStyles, BORDER, TEXT_SECONDARY, DARK_BG} from './sharedStyles';
 
 const TARGET_SIZE_TEMPLATES: {label: string; value: string; unit: SizeUnit}[] = [
   {label: 'Discord 10MB', value: '10', unit: 'MB'},
+  {label: 'X (Twitter) 5MB', value: '5', unit: 'MB'},
+  {label: 'LINE 10MB', value: '10', unit: 'MB'},
+  {label: 'Instagram 8MB', value: '8', unit: 'MB'},
 ];
 
 interface TargetSizePanelProps {


### PR DESCRIPTION
## 概要
Closes #141

`TARGET_SIZE_TEMPLATES` に X (Twitter) 5MB、LINE 10MB、Instagram 8MB のプリセットを追加。

## 変更内容
- `TargetSizePanel.tsx`: `TARGET_SIZE_TEMPLATES` に3件のエントリを追加

## 影響範囲
- UIのみの変更（ロジック変更なし）
- 既存テストへの影響なし