### PR TITLE
feat: 変換履歴の動画サムネイルを実際の先頭フレームに置き換える (#144)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,8 @@
     "react-native-screens": "~4.23.0",
     "react-native-share": "^12.2.5",
     "react-native-svg": "^15.15.3",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "expo-video-thumbnails": "~8.1.6"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/app/src/__tests__/ConversionHistoryModal.test.tsx
+++ b/app/src/__tests__/ConversionHistoryModal.test.tsx
@@ -15,6 +15,10 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   removeItem: jest.fn(),
 }));
 
+jest.mock('expo-video-thumbnails', () => ({
+  getThumbnailAsync: jest.fn().mockResolvedValue({uri: 'file:///thumb.jpg'}),
+}));
+
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({top: 0, bottom: 0, left: 0, right: 0}),
   SafeAreaProvider: ({children}: {children: React.ReactNode}) => children,
@@ -191,5 +195,29 @@ describe('ConversionHistoryModal', () => {
     expect(mockedClearHistory).toHaveBeenCalledTimes(1);
     const json = JSON.stringify(renderer.toJSON());
     expect(json).not.toContain('sample_out.jpg');
+  });
+});
+
+describe('ビデオサムネイル', () => {
+  it('mediaType=videoのアイテムで getThumbnailAsync が呼ばれる', async () => {
+    const VideoThumbnails = require('expo-video-thumbnails');
+    const mockedGetHistory = require('../data/history/conversionHistory').getConversionHistory as jest.Mock;
+    const videoItem: ConversionHistoryItem = {
+      id: 'vid-1',
+      createdAt: new Date().toISOString(),
+      inputBytes: 5000,
+      outputBytes: 3000,
+      outputPath: '/cache/out.mp4',
+      mediaType: 'video',
+      params: {action: 'convert'},
+    };
+    mockedGetHistory.mockResolvedValueOnce([videoItem]);
+    await createWithData([videoItem]);
+    // 非同期処理の完了を待つ
+    await ReactTestRenderer.act(async () => {});
+    expect(VideoThumbnails.getThumbnailAsync).toHaveBeenCalledWith(
+      expect.stringContaining('out.mp4'),
+      {time: 0},
+    );
   });
 });

--- a/app/src/screens/components/ConversionHistoryModal.tsx
+++ b/app/src/screens/components/ConversionHistoryModal.tsx
@@ -10,6 +10,7 @@ import {
   ActivityIndicator,
   Image,
 } from 'react-native';
+import * as VideoThumbnails from 'expo-video-thumbnails';
 import {
   ConversionHistoryItem,
   clearConversionHistory,
@@ -51,7 +52,44 @@ function actionLabel(action: ConversionHistoryItem['params']['action']): string 
 
 const HistoryItemThumbnail: React.FC<{uri: string; mediaType?: 'image' | 'video'}> = ({uri, mediaType}) => {
   const [error, setError] = useState(false);
+  const [videoThumbUri, setVideoThumbUri] = useState<string | null>(null);
+  const [videoThumbLoading, setVideoThumbLoading] = useState(false);
+
+  useEffect(() => {
+    if (mediaType !== 'video') return;
+    let cancelled = false;
+    setVideoThumbLoading(true);
+    VideoThumbnails.getThumbnailAsync(uri, {time: 0})
+      .then(({uri: thumbUri}) => {
+        if (!cancelled) setVideoThumbUri(thumbUri);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setVideoThumbLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [uri, mediaType]);
+
   if (mediaType === 'video') {
+    if (videoThumbLoading) {
+      return (
+        <View style={styles.thumbnail} accessibilityLabel="動画サムネイル読み込み中">
+          <ActivityIndicator size="small" color="#aaa" />
+        </View>
+      );
+    }
+    if (videoThumbUri && !error) {
+      return (
+        <Image
+          source={{uri: videoThumbUri}}
+          style={styles.thumbnail}
+          accessibilityLabel="変換後動画のサムネイル"
+          onError={() => setError(true)}
+        />
+      );
+    }
     return (
       <View style={styles.thumbnail} accessibilityLabel="変換後動画のサムネイル">
         <Text style={styles.thumbnailFallback}>🎬</Text>


### PR DESCRIPTION
## 概要

変換履歴モーダルで動画ファイルのサムネイルを🎬アイコンから実際の先頭フレーム画像に置き換える。

## 変更内容

- `package.json`: `expo-video-thumbnails ~8.1.6` を追加
- `ConversionHistoryModal.tsx`: `expo-video-thumbnails` をインポートし `HistoryItemThumbnail` で useEffect を使って非同期取得
  - 取得中は ActivityIndicator を表示
  - 成功時は Image コンポーネントでサムネイル表示
  - 失敗時は🎬アイコンにフォールバック
- `ConversionHistoryModal.test.tsx`: `expo-video-thumbnails` モック追加、`getThumbnailAsync` 呼び出しのテスト追加

## 関連

Closes #144