### PR TITLE
feat: 指定サイズ圧縮で目標未達の場合に警告メッセージを表示する (#146)

### DIFF
--- a/app/src/__tests__/MainScreen.test.tsx
+++ b/app/src/__tests__/MainScreen.test.tsx
@@ -109,4 +109,10 @@ describe('MainScreen', () => {
     const btn = getByRole('button', { name: 'Run blocky effect' });
     expect(btn.props.accessibilityState?.disabled ?? btn.props.disabled).toBeTruthy();
   });
+
+  it('目標サイズ未達の警告エリアは初期状態では表示されない', () => {
+    const { queryByRole } = render(<MainScreen />);
+    // accessibilityRole="alert" の警告は初期状態では存在しない
+    expect(queryByRole('alert')).toBeNull();
+  });
 });

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -98,6 +98,9 @@ const DICT: Dict = {
   gifFpsSlider: {ja: 'GIF フレームレートスライダー', en: 'GIF frame rate slider'},
   gifScale: {ja: 'GIF スケール率', en: 'GIF Scale'},
   gifScaleSlider: {ja: 'GIF スケール率スライダー', en: 'GIF scale slider'},
+  targetSizeNotReachedPrefix: {ja: '目標サイズ（', en: 'Could not reach target size ('},
+  targetSizeNotReachedMiddle: {ja: '）を達成できませんでした（結果: ', en: '), result: '},
+  targetSizeNotReachedSuffix: {ja: '）', en: ')'},
 };
 
 export const t = (key: keyof typeof DICT): string => {

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -113,6 +113,7 @@ const MainScreen = () => {
   });
 
   const [processingAction, setProcessingAction] = useState<'gabigabi' | 'convert' | 'targetSize' | null>(null);
+  const [targetSizeNotReached, setTargetSizeNotReached] = useState<{target: number; actual: number} | null>(null);
 
   // #77: fullscreen modal state
   const [fullscreenUri, setFullscreenUri] = useState<string | null>(null);
@@ -573,6 +574,7 @@ const MainScreen = () => {
     setSelectedMediaType(null);
     setProcessedImage(null);
     outputBytesRef.current = 0;
+    setTargetSizeNotReached(null);
   };
 
   const handleTargetSizeProcess = async () => {
@@ -599,6 +601,7 @@ const MainScreen = () => {
       const result = await compressToTargetSize(selectedImage, targetBytes, videoOutputFormat);
       setProcessedImage(result.outputUri);
       outputBytesRef.current = result.outputBytes;
+      setTargetSizeNotReached(result.outputBytes > targetBytes ? {target: targetBytes, actual: result.outputBytes} : null);
       await saveHistory('targetSize', selectedImage, result.outputUri, inputBytes, result.outputBytes, targetBytes);
       await notifyProcessingResult(t('notifyCompressCompleted'), processingNotificationId);
     } catch (err) {
@@ -712,6 +715,13 @@ const MainScreen = () => {
                 outputFormat={outputFormat}
                 showAfterConversion={t('showAfterConversion')}
               />
+            )}
+            {targetSizeNotReached && (
+              <View style={styles.targetSizeWarning} accessibilityRole="alert">
+                <Text style={styles.targetSizeWarningText}>
+                  ⚠️ {t('targetSizeNotReachedPrefix')}{formatBytes(targetSizeNotReached.target)}{t('targetSizeNotReachedMiddle')}{formatBytes(targetSizeNotReached.actual)}{t('targetSizeNotReachedSuffix')}
+                </Text>
+              </View>
             )}
           </View>
         </View>
@@ -1099,6 +1109,20 @@ const styles = StyleSheet.create({
     paddingTop: 12,
     paddingBottom: 32,
     gap: 10,
+  },
+
+  targetSizeWarning: {
+    backgroundColor: '#3a2000',
+    borderWidth: 1,
+    borderColor: '#ff9800',
+    borderRadius: 8,
+    padding: 10,
+    marginTop: 6,
+  },
+  targetSizeWarningText: {
+    color: '#ff9800',
+    fontSize: 12,
+    fontWeight: '600',
   },
 });
 


### PR DESCRIPTION
## 概要

指定サイズ圧縮の結果が目標サイズを超えている場合、UI上に警告メッセージを表示する。

## 変更内容

- `MainScreen.tsx`: `targetSizeNotReached` ステートを追加し、`handleTargetSizeProcess` で `outputBytes > targetBytes` を検知して設定
- AfterInfoBlock の下に警告エリア（オレンジ枠）を条件付きで表示
- `i18n.ts`: `targetSizeNotReachedPrefix/Middle/Suffix` キーを追加（ja/en）
- `MainScreen.test.tsx`: 警告エリアの初期非表示テストを追加

## 関連

Closes #146