### PR TITLE
fix: expo-video-thumbnailsのバージョンを~55.0.14に修正してCIを修復する

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -18,6 +18,7 @@
         "expo-image-picker": "^16.1.4",
         "expo-media-library": "~17.1.6",
         "expo-notifications": "~0.32.12",
+        "expo-video-thumbnails": "~55.0.14",
         "ffmpeg-kit-react-native": "npm:@wokcito/ffmpeg-kit-react-native@^6.1.2",
         "react": "19.2.0",
         "react-native": "0.83.2",
@@ -9089,6 +9090,15 @@
       "version": "55.1.3",
       "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-55.1.3.tgz",
       "integrity": "sha512-UVVIiZqymQZJL+o/jh65kXOI97xdkbqBJJM0LMabaPMNLFnc6/WvOMOzmQs7SPyKb8+0PeBaFd7tj5DzF6JeQg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-video-thumbnails": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-video-thumbnails/-/expo-video-thumbnails-55.0.14.tgz",
+      "integrity": "sha512-OeUXzElV/+iXXtzLFgjQKGKRlRh3qcqarEMKBMLQKO4LZ39H8EtJIs+DsEMs/UM9fPe5Xhi5dm2QkNblJQxLtg==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "expo-image-picker": "^16.1.4",
     "expo-media-library": "~17.1.6",
     "expo-notifications": "~0.32.12",
+    "expo-video-thumbnails": "~55.0.14",
     "ffmpeg-kit-react-native": "npm:@wokcito/ffmpeg-kit-react-native@^6.1.2",
     "react": "19.2.0",
     "react-native": "0.83.2",
@@ -28,8 +29,7 @@
     "react-native-screens": "~4.23.0",
     "react-native-share": "^12.2.5",
     "react-native-svg": "^15.15.3",
-    "zustand": "^5.0.5",
-    "expo-video-thumbnails": "~8.1.6"
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## 概要

PR #148 で追加した `expo-video-thumbnails` のバージョン指定 `~8.1.6` が npm に存在しないため CI が失敗していた。

SDK 55 と互換性のある正しいバージョン `~55.0.14` に修正する。

## 変更内容

- `app/package.json`: `expo-video-thumbnails` を `~8.1.6` → `~55.0.14` に変更
- `app/package-lock.json`: ロックファイルを更新

## 影響範囲

- CI のみ（パッケージバージョン修正）
- 機能的な変更なし