### PR TITLE
fix: 変換履歴のoutputPathがアプリ再起動後に無効になる問題を修正する (#155)

### DIFF
--- a/app/src/data/ffmpeg/ffmpegUtils.ts
+++ b/app/src/data/ffmpeg/ffmpegUtils.ts
@@ -1,6 +1,7 @@
 import { FFmpegSession } from 'ffmpeg-kit-react-native';
 import { Paths } from 'expo-file-system';
 import * as FileSystem from 'expo-file-system/legacy';
+import {getConversionHistory} from '../history/conversionHistory';
 
 /**
  * ユニークなファイル名サフィックスを生成する。
@@ -73,9 +74,19 @@ export async function cleanupCachedTempFiles(): Promise<void> {
     if (!dirInfo.exists) return;
     const result = await FileSystem.readDirectoryAsync(cacheDir);
     const tempPattern = /_(compressed|gabigabi|converted)_|_passlog/;
+
+    // 変換履歴のoutputPathに含まれるファイルはスキップ（案C: #155）
+    const history = await getConversionHistory();
+    const historyFileNames = new Set(
+      history.map(item => {
+        const p = item.outputPath.startsWith('file://') ? item.outputPath.slice(7) : item.outputPath;
+        return p.split('/').pop() ?? '';
+      }).filter(Boolean),
+    );
+
     await Promise.all(
       result
-        .filter(name => tempPattern.test(name))
+        .filter(name => tempPattern.test(name) && !historyFileNames.has(name))
         .map(name => FileSystem.deleteAsync(cacheDir + name, { idempotent: true })),
     );
   } catch {

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -90,6 +90,7 @@ const DICT: Dict = {
   clearHistoryTitle: {ja: '履歴を全削除', en: 'Clear all history'},
   clearHistoryMessage: {ja: '変換履歴をすべて削除しますか？この操作は取り消せません。', en: 'Delete all conversion history? This cannot be undone.'},
   clearHistoryConfirm: {ja: '削除', en: 'Delete'},
+  fileNotFound: {ja: 'ファイルが見つかりません', en: 'File not found'},
   cancel: {ja: 'キャンセル', en: 'Cancel'},
   actionGabigabi: {ja: 'ガビガビ化', en: 'Blocky'},
   actionConvert: {ja: '変換', en: 'Convert'},

--- a/app/src/screens/components/ConversionHistoryModal.tsx
+++ b/app/src/screens/components/ConversionHistoryModal.tsx
@@ -10,6 +10,7 @@ import {
   ActivityIndicator,
   Image,
 } from 'react-native';
+import * as FileSystem from 'expo-file-system/legacy';
 import * as VideoThumbnails from 'expo-video-thumbnails';
 import {
   ConversionHistoryItem,
@@ -115,6 +116,15 @@ const HistoryItemThumbnail: React.FC<{uri: string; mediaType?: 'image' | 'video'
 };
 
 const HistoryItem: React.FC<{item: ConversionHistoryItem}> = ({item}) => {
+  const [fileExists, setFileExists] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const path = item.outputPath.startsWith('file://') ? item.outputPath : `file://${item.outputPath}`;
+    FileSystem.getInfoAsync(path)
+      .then(info => setFileExists(info.exists))
+      .catch(() => setFileExists(false));
+  }, [item.outputPath]);
+
   const ratio = item.inputBytes > 0
     ? Math.round((item.outputBytes / item.inputBytes) * 100)
     : 0;
@@ -123,7 +133,7 @@ const HistoryItem: React.FC<{item: ConversionHistoryItem}> = ({item}) => {
   const thumbnailUri = item.outputPath.startsWith('file://') ? item.outputPath : `file://${item.outputPath}`;
 
   return (
-    <View style={styles.itemCard} accessible={true} accessibilityLabel={a11yLabel}>
+    <View style={[styles.itemCard, fileExists === false && styles.itemCardUnavailable]} accessible={true} accessibilityLabel={a11yLabel}>
       <View style={styles.itemRow}>
         <HistoryItemThumbnail uri={thumbnailUri} mediaType={item.mediaType} />
         <View style={styles.itemContent}>
@@ -134,14 +144,18 @@ const HistoryItem: React.FC<{item: ConversionHistoryItem}> = ({item}) => {
             </View>
           </View>
           <Text style={styles.itemFileName} numberOfLines={1} ellipsizeMode="middle">📄 {fileName}</Text>
-          <View style={styles.itemSizeRow}>
-            <Text style={styles.itemSize}>{formatBytes(item.inputBytes)}</Text>
-            <Text style={styles.itemArrow}>→</Text>
-            <Text style={[styles.itemSize, ratio < 100 ? styles.sizeReduced : styles.sizeIncreased]}>
-              {formatBytes(item.outputBytes)}
-            </Text>
-            <Text style={styles.itemRatio}>({ratio}%)</Text>
-          </View>
+          {fileExists === false ? (
+            <Text style={styles.fileNotFoundText}>{t('fileNotFound')}</Text>
+          ) : (
+            <View style={styles.itemSizeRow}>
+              <Text style={styles.itemSize}>{formatBytes(item.inputBytes)}</Text>
+              <Text style={styles.itemArrow}>→</Text>
+              <Text style={[styles.itemSize, ratio < 100 ? styles.sizeReduced : styles.sizeIncreased]}>
+                {formatBytes(item.outputBytes)}
+              </Text>
+              <Text style={styles.itemRatio}>({ratio}%)</Text>
+            </View>
+          )}
         </View>
       </View>
     </View>
@@ -314,6 +328,14 @@ const styles = StyleSheet.create({
     padding: 14,
     marginBottom: 10,
     gap: 6,
+  },
+  itemCardUnavailable: {
+    opacity: 0.5,
+  },
+  fileNotFoundText: {
+    fontSize: 12,
+    color: ACCENT,
+    fontStyle: 'italic',
   },
   itemRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## 概要
Closes #155

アプリ再起動後にキャッシュファイルが削除されることで変換履歴の outputPath が無効になる問題を修正します。

## 修正方針

**案B + 案C を併用:**

### 案B（表示側）
- `ConversionHistoryModal.tsx` でアイテム表示時にファイル存在確認を行う（`expo-file-system` の `getInfoAsync`）
- ファイルが存在しない場合は「ファイルが見つかりません」と表示し、アイテムを半透明化して無効状態にする

### 案C（削除側）
- `cleanupCachedTempFiles()` で削除する前に変換履歴の outputPath に含まれるファイル名を取得
- 履歴に参照されているファイルは削除対象から除外する

## 変更ファイル
- `src/data/ffmpeg/ffmpegUtils.ts`: cleanupCachedTempFiles() に履歴スキップロジックを追加
- `src/screens/components/ConversionHistoryModal.tsx`: ファイル存在確認とUI制御を追加
- `src/i18n.ts`: `fileNotFound` キーを追加（日英）