### PR TITLE
test: conversionHistory.ts の saveConversionHistoryItem MAX_ITEMS境界テストを追加する

### DIFF
--- a/app/src/__tests__/conversionHistory.test.ts
+++ b/app/src/__tests__/conversionHistory.test.ts
@@ -44,6 +44,38 @@ describe('conversionHistory', () => {
     expect(rows).toEqual([]);
   });
 
+  it('50件を超えた場合に古い履歴を切り捨てる', async () => {
+    const existing = Array.from({length: 50}, (_, i) => ({
+      id: `old-${i}`,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      inputPath: 'file:///in.jpg',
+      outputPath: 'file:///out.jpg',
+      inputBytes: 100,
+      outputBytes: 50,
+      mediaType: 'image' as const,
+      params: {action: 'gabigabi' as const},
+    }));
+    mockedAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(existing));
+
+    const newItem = {
+      id: 'newest',
+      createdAt: '2026-03-22T00:00:00.000Z',
+      inputPath: 'file:///in.jpg',
+      outputPath: 'file:///out.jpg',
+      inputBytes: 200,
+      outputBytes: 100,
+      mediaType: 'image' as const,
+      params: {action: 'gabigabi' as const},
+    };
+    await saveConversionHistoryItem(newItem);
+
+    const saved = JSON.parse(mockedAsyncStorage.setItem.mock.calls[0][1]);
+    expect(saved).toHaveLength(50);
+    expect(saved[0].id).toBe('newest');
+    // 最古のold-49が切り捨てられ、old-48が末尾になること
+    expect(saved[49].id).toBe('old-48');
+  });
+
   it('新しい履歴を先頭に追加して保存する', async () => {
     mockedAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify([{id: 'old'}]));
 


### PR DESCRIPTION
## 概要

#162 対応。

`saveConversionHistoryItem` の50件（MAX_ITEMS）上限を超えた場合に古い履歴が切り捨てられることを検証するユニットテストを追加。

## 変更内容

- `conversionHistory.test.ts` に以下テストケースを追加:
  - 50件を超えた場合に古い履歴を切り捨てる（長さ50になり、最新アイテムが先頭、最古が削除される）

## 既存カバレッジとの関係

既存テストで `clearConversionHistory` は十分カバーされていることを確認。`deleteConversionHistoryItem` の存在しないID指定も既存テストでカバー済み。

Closes #162