### PR TITLE
feat: 変換履歴アイテムをタップして出力ファイルを共有できるようにする

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -18,6 +18,7 @@
         "expo-image-picker": "^16.1.4",
         "expo-media-library": "~17.1.6",
         "expo-notifications": "~0.32.12",
+        "expo-sharing": "^55.0.18",
         "expo-video-thumbnails": "~55.0.14",
         "ffmpeg-kit-react-native": "npm:@wokcito/ffmpeg-kit-react-native@^6.1.2",
         "react": "19.2.0",
@@ -2264,13 +2265,13 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "55.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.6.tgz",
-      "integrity": "sha512-cIox6FjZlFaaX40rbQ3DvP9e87S5X85H9uw+BAxJE5timkMhuByy3GAlOsj1h96EyzSiol7Q6YIGgY1Jiz4M+A==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz",
+      "integrity": "sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "~10.0.12",
+        "@expo/json-file": "~10.0.13",
         "@expo/plist": "^0.5.2",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
@@ -2528,9 +2529,9 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "10.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.12.tgz",
-      "integrity": "sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==",
+      "version": "10.0.14",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.14.tgz",
+      "integrity": "sha512-yWwBFywFv+SxkJp/pIzzA416JVYflNUh7pqQzgaA6nXDqRyK7KfrqVzk8PdUfDnqbBcaZZxpzNssfQZzp5KHrA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -9084,6 +9085,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-sharing": {
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-55.0.18.tgz",
+      "integrity": "sha512-Tqy4LXRLw/UEg5mT7BKhx8y4ReNz8fVldvhHJV5cesH3kRgEerHkYxVwid2vd7v34KnNp0RH1OqUyDlzZTQ9AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "^55.0.8",
+        "@expo/config-types": "^55.0.5",
+        "@expo/plist": "^0.5.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-updates-interface": {

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "expo-image-picker": "^16.1.4",
     "expo-media-library": "~17.1.6",
     "expo-notifications": "~0.32.12",
+    "expo-sharing": "^55.0.18",
     "expo-video-thumbnails": "~55.0.14",
     "ffmpeg-kit-react-native": "npm:@wokcito/ffmpeg-kit-react-native@^6.1.2",
     "react": "19.2.0",

--- a/app/src/__tests__/ConversionHistoryModal.test.tsx
+++ b/app/src/__tests__/ConversionHistoryModal.test.tsx
@@ -26,6 +26,11 @@ jest.mock('expo-file-system/legacy', () => ({
   cacheDirectory: 'file:///cache/',
 }));
 
+jest.mock('expo-sharing', () => ({
+  isAvailableAsync: jest.fn().mockResolvedValue(true),
+  shareAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock('expo-video-thumbnails', () => ({
   getThumbnailAsync: jest.fn().mockResolvedValue({uri: 'file:///thumb.jpg'}),
 }));
@@ -390,5 +395,67 @@ describe('フィルタータブ機能', () => {
     const gabiTab2 = findFilterTab(renderer, 'Blocky');
     expect(allTab2!.props.accessibilityState?.selected).toBe(true);
     expect(gabiTab2!.props.accessibilityState?.selected).toBe(false);
+  });
+});
+
+describe('共有機能 (Issue #165)', () => {
+  const Sharing = require('expo-sharing');
+  const FileSystemMock = require('expo-file-system/legacy');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    Sharing.isAvailableAsync.mockResolvedValue(true);
+    Sharing.shareAsync.mockResolvedValue(undefined);
+    FileSystemMock.getInfoAsync.mockResolvedValue({exists: true, isDirectory: false});
+  });
+
+  it('ファイルが存在する場合、共有ボタンが有効である', async () => {
+    FileSystemMock.getInfoAsync.mockResolvedValue({exists: true, isDirectory: false});
+    const renderer = await createWithData([sampleItem]);
+    await ReactTestRenderer.act(async () => {});
+
+    const shareBtns = renderer.root.findAll(
+      (node: ReactTestRenderer.ReactTestInstance) =>
+        node.props.accessibilityRole === 'button' &&
+        (node.props.accessibilityLabel === 'Share file' || node.props.accessibilityLabel === 'ファイルを共有'),
+    );
+    expect(shareBtns.length).toBeGreaterThan(0);
+    expect(shareBtns[0].props.accessibilityState?.disabled).toBe(false);
+  });
+
+  it('ファイルが存在しない場合、共有ボタンが無効である', async () => {
+    FileSystemMock.getInfoAsync.mockResolvedValue({exists: false, isDirectory: false});
+    const renderer = await createWithData([sampleItem]);
+    await ReactTestRenderer.act(async () => {});
+
+    const shareBtns = renderer.root.findAll(
+      (node: ReactTestRenderer.ReactTestInstance) =>
+        node.props.accessibilityRole === 'button' &&
+        (node.props.accessibilityLabel === 'Share file' || node.props.accessibilityLabel === 'ファイルを共有'),
+    );
+    expect(shareBtns.length).toBeGreaterThan(0);
+    expect(shareBtns[0].props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('共有ボタンを押すと Sharing.shareAsync が呼ばれる', async () => {
+    FileSystemMock.getInfoAsync.mockResolvedValue({exists: true, isDirectory: false});
+    const renderer = await createWithData([sampleItem]);
+    await ReactTestRenderer.act(async () => {});
+
+    const shareBtns = renderer.root.findAll(
+      (node: ReactTestRenderer.ReactTestInstance) =>
+        node.props.accessibilityRole === 'button' &&
+        (node.props.accessibilityLabel === 'Share file' || node.props.accessibilityLabel === 'ファイルを共有'),
+    );
+    expect(shareBtns.length).toBeGreaterThan(0);
+
+    await ReactTestRenderer.act(async () => {
+      shareBtns[0].props.onPress?.();
+    });
+
+    expect(Sharing.shareAsync).toHaveBeenCalledWith(
+      expect.stringContaining('sample_out.jpg'),
+    );
   });
 });

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -102,6 +102,7 @@ const DICT: Dict = {
   historyParamConvert: {ja: '{inputFmt} → {outputFmt}', en: '{inputFmt} → {outputFmt}'},
   historyParamTargetSize: {ja: '目標: {target} / 結果: {result}', en: 'Target: {target} / Result: {result}'},
   historyParamCompression: {ja: '圧縮率: {rate}% / {format}', en: 'Compression: {rate}% / {format}'},
+  shareHistoryItem: {ja: 'ファイルを共有', en: 'Share file'},
   filterAll: {ja: 'すべて', en: 'All'},
   gifFps: {ja: 'GIF フレームレート', en: 'GIF Frame Rate'},
   gifFpsSlider: {ja: 'GIF フレームレートスライダー', en: 'GIF frame rate slider'},

--- a/app/src/screens/components/ConversionHistoryModal.tsx
+++ b/app/src/screens/components/ConversionHistoryModal.tsx
@@ -11,6 +11,7 @@ import {
   Image,
 } from 'react-native';
 import * as FileSystem from 'expo-file-system/legacy';
+import * as Sharing from 'expo-sharing';
 import * as VideoThumbnails from 'expo-video-thumbnails';
 import {
   ConversionHistoryItem,
@@ -146,6 +147,17 @@ const HistoryItem: React.FC<{item: ConversionHistoryItem; onDelete: (id: string)
       .catch(() => setFileExists(false));
   }, [item.outputPath]);
 
+  const handleShare = useCallback(async () => {
+    const path = item.outputPath.startsWith('file://') ? item.outputPath : `file://${item.outputPath}`;
+    try {
+      const isAvailable = await Sharing.isAvailableAsync();
+      if (!isAvailable) return;
+      await Sharing.shareAsync(path);
+    } catch {
+      // 共有に失敗した場合は無視
+    }
+  }, [item.outputPath]);
+
   const ratio = item.inputBytes > 0
     ? Math.round((item.outputBytes / item.inputBytes) * 100)
     : 0;
@@ -170,6 +182,15 @@ const HistoryItem: React.FC<{item: ConversionHistoryItem; onDelete: (id: string)
                 accessibilityRole="button"
                 accessibilityLabel={t('deleteHistoryItemTitle')}>
                 <Text style={styles.deleteButtonText}>✕</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={handleShare}
+                disabled={fileExists !== true}
+                style={[styles.shareButton, fileExists !== true && styles.shareButtonDisabled]}
+                accessibilityRole="button"
+                accessibilityLabel={t('shareHistoryItem')}
+                accessibilityState={{disabled: fileExists !== true}}>
+                <Text style={[styles.shareButtonText, fileExists !== true && styles.shareButtonTextDisabled]}>↑</Text>
               </TouchableOpacity>
             </View>
           </View>
@@ -434,6 +455,27 @@ const styles = StyleSheet.create({
     fontSize: 11,
     fontWeight: '700',
     lineHeight: 14,
+  },
+  shareButton: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: '#103a2a',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: 4,
+  },
+  shareButtonDisabled: {
+    backgroundColor: '#1e1e1e',
+  },
+  shareButtonText: {
+    color: '#4caf90',
+    fontSize: 13,
+    fontWeight: '700',
+    lineHeight: 15,
+  },
+  shareButtonTextDisabled: {
+    color: '#555',
   },
   itemDate: {
     fontSize: 12,


### PR DESCRIPTION
## 概要
Issue #165 対応。変換履歴モーダルで変換済みファイルを共有シートで共有できるようにする。

## 変更内容
- `expo-sharing` を依存関係に追加（`^55.0.18`）
- `HistoryItem` に共有ボタン（↑）を追加
  - ファイルが存在する場合のみ有効（緑色表示）
  - ファイルが存在しない場合は無効（グレー表示）
- `Sharing.shareAsync(outputPath)` でOS標準の共有シートを開く
- `i18n.ts` に `shareHistoryItem` キーを追加（日本語: ファイルを共有 / 英語: Share file）
- テストを追加:
  - ファイルが存在する場合、共有ボタンが有効である
  - ファイルが存在しない場合、共有ボタンが無効である
  - 共有ボタンを押すと `Sharing.shareAsync` が呼ばれる

## 受入条件
- [x] ファイルが存在する履歴アイテムから共有シートを開ける
- [x] ファイルが存在しないアイテムでは共有操作が無効になる
- [x] テストを追加する

Closes #165