### PR TITLE
fix: ConversionHistoryModal・MainScreen テストの expo-sharing モック追加 (#186)

### DIFF
--- a/app/src/__tests__/MainScreen.test.tsx
+++ b/app/src/__tests__/MainScreen.test.tsx
@@ -20,6 +20,11 @@ jest.mock('expo-image-picker', () => ({
   MediaTypeOptions: { All: 'All', Images: 'Images', Videos: 'Videos' },
 }));
 
+jest.mock('expo-sharing', () => ({
+  isAvailableAsync: jest.fn().mockResolvedValue(true),
+  shareAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock('expo-file-system/legacy', () => ({
   getInfoAsync: jest.fn().mockResolvedValue({ exists: false, size: 0 }),
   readDirectoryAsync: jest.fn(),


### PR DESCRIPTION
## 概要
Closes #186

MainScreen.test.tsx に `expo-sharing` モックが欠落しており、テストが失敗していた問題を修正。

## 変更内容
- `app/src/__tests__/MainScreen.test.tsx` に `expo-sharing` モックを追加

```ts
jest.mock('expo-sharing', () => ({
  isAvailableAsync: jest.fn().mockResolvedValue(true),
  shareAsync: jest.fn().mockResolvedValue(undefined),
}));
```