### PR TITLE
test: ImageModal・ErrorModal・FileSizeLabel コンポーネントのユニットテストを追加する

### DIFF
--- a/app/src/__tests__/ErrorModal.test.tsx
+++ b/app/src/__tests__/ErrorModal.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * ErrorModal コンポーネントのユニットテスト
+ * Issue #190
+ */
+
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+jest.mock('../i18n', () => ({
+  t: (key: string) => key,
+}));
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+import ErrorModal from '../components/ErrorModal';
+
+describe('ErrorModal', () => {
+  it('visible=true のとき正常にレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ErrorModal
+          visible={true}
+          message="テストエラーメッセージ"
+          onClose={jest.fn()}
+        />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('visible=false のとき Modal は閉じた状態でレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ErrorModal
+          visible={false}
+          message="テストエラーメッセージ"
+          onClose={jest.fn()}
+        />,
+      );
+    });
+    expect(renderer!.toJSON()).toBeNull();
+  });
+
+  it('カスタム title が表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ErrorModal
+          visible={true}
+          title="カスタムタイトル"
+          message="エラー内容"
+          onClose={jest.fn()}
+        />,
+      );
+    });
+    const texts = renderer!.root.findAll(el => el.props.children === 'カスタムタイトル');
+    expect(texts.length).toBeGreaterThan(0);
+  });
+
+  it('message テキストが表示される', async () => {
+    const msg = 'エラー詳細メッセージ';
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ErrorModal visible={true} message={msg} onClose={jest.fn()} />,
+      );
+    });
+    const texts = renderer!.root.findAll(el => el.props.children === msg);
+    expect(texts.length).toBeGreaterThan(0);
+  });
+
+  it('title を省略すると t("error") がデフォルトタイトルになる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ErrorModal visible={true} message="エラー" onClose={jest.fn()} />,
+      );
+    });
+    // t('error') → 'error' (モック)
+    const texts = renderer!.root.findAll(el => el.props.children === 'error');
+    expect(texts.length).toBeGreaterThan(0);
+  });
+});

--- a/app/src/__tests__/FileSizeLabel.test.tsx
+++ b/app/src/__tests__/FileSizeLabel.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * FileSizeLabel コンポーネントのユニットテスト
+ * Issue #190
+ */
+
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+jest.mock('expo-file-system', () => ({
+  getInfoAsync: jest.fn().mockResolvedValue({exists: true, size: 2048}),
+}));
+
+jest.mock('../data/ffmpeg/ffmpegUtils', () => ({
+  getFileSizeBytes: jest.fn((info: {size?: number}) => info.size ?? 0),
+}));
+
+import FileSizeLabel from '../components/FileSizeLabel';
+
+describe('FileSizeLabel', () => {
+  it('uri が空文字のとき null をレンダリングする', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <FileSizeLabel label="元のサイズ" uri="" />,
+      );
+    });
+    expect(renderer!.toJSON()).toBeNull();
+  });
+
+  it('uri が指定されているとき getInfoAsync を呼び出す', async () => {
+    const {getInfoAsync} = require('expo-file-system');
+    await ReactTestRenderer.act(async () => {
+      ReactTestRenderer.create(
+        <FileSizeLabel label="元のサイズ" uri="file:///test/image.jpg" />,
+      );
+    });
+    expect(getInfoAsync).toHaveBeenCalled();
+  });
+
+  it('ファイルサイズ取得後にラベルが描画される（クラッシュしない）', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(async () => {
+      renderer = ReactTestRenderer.create(
+        <FileSizeLabel label="元のサイズ" uri="file:///test/image.jpg" />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeUndefined();
+  });
+
+  it('getInfoAsync が失敗したとき "—" を表示する', async () => {
+    const {getInfoAsync} = require('expo-file-system');
+    getInfoAsync.mockRejectedValueOnce(new Error('fail'));
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(async () => {
+      renderer = ReactTestRenderer.create(
+        <FileSizeLabel label="元のサイズ" uri="file:///test/bad.jpg" />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeUndefined();
+  });
+
+  it('file:// プレフィックスなしの URI も正しく処理される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(async () => {
+      renderer = ReactTestRenderer.create(
+        <FileSizeLabel label="変換後" uri="/test/image.jpg" />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeUndefined();
+  });
+});

--- a/app/src/__tests__/ImageModal.test.tsx
+++ b/app/src/__tests__/ImageModal.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * ImageModal コンポーネントのユニットテスト
+ * Issue #190
+ */
+
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+jest.mock('../i18n', () => ({
+  t: (key: string) => key,
+}));
+
+import ImageModal from '../components/ImageModal';
+
+describe('ImageModal', () => {
+  it('uri=null のとき null をレンダリングする', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ImageModal uri={null} visible={false} onClose={jest.fn()} />,
+      );
+    });
+    expect(renderer!.toJSON()).toBeNull();
+  });
+
+  it('uri と visible=true のとき正常にレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ImageModal
+          uri="file:///test/image.jpg"
+          visible={true}
+          onClose={jest.fn()}
+        />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('visible=false のとき Modal は閉じた状態', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ImageModal
+          uri="file:///test/image.jpg"
+          visible={false}
+          onClose={jest.fn()}
+        />,
+      );
+    });
+    expect(renderer!.toJSON()).toBeNull();
+  });
+
+  it('onClose コールバックが関数として渡せる', async () => {
+    const onClose = jest.fn();
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ImageModal uri="file:///test/image.jpg" visible={true} onClose={onClose} />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要
Closes #190

## 変更内容
- `app/src/__tests__/ImageModal.test.tsx` 追加: 表示/非表示の切り替え・URIなし・コールバックのテスト
- `app/src/__tests__/ErrorModal.test.tsx` 追加: エラーメッセージ表示・カスタムタイトル・デフォルトタイトル・visible切り替えのテスト
- `app/src/__tests__/FileSizeLabel.test.tsx` 追加: 空URI・getInfoAsync呼び出し・エラー時・プレフィックスなしURIのテスト

## テスト
CI (Jest) で確認予定