### PR TITLE
test: ResizeSlider・ImagePicker コンポーネントのユニットテストを追加する

### DIFF
--- a/app/src/__tests__/ImagePicker.test.tsx
+++ b/app/src/__tests__/ImagePicker.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * ImagePicker コンポーネントのユニットテスト
+ * Issue #191
+ */
+
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+jest.mock('../i18n', () => ({
+  t: (key: string) => key,
+}));
+
+jest.mock('expo-image-picker', () => ({
+  requestMediaLibraryPermissionsAsync: jest.fn().mockResolvedValue({status: 'granted'}),
+  launchImageLibraryAsync: jest.fn().mockResolvedValue({canceled: true}),
+}));
+
+import ImagePicker from '../components/ImagePicker';
+
+describe('ImagePicker', () => {
+  it('selectedImage なしで正常にレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ImagePicker onImageSelect={jest.fn()} />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('selectedImage あり・image タイプでレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ImagePicker
+          onImageSelect={jest.fn()}
+          selectedImage="file:///test/image.jpg"
+          selectedMediaType="image"
+        />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('selectedMediaType=video のとき動画アイコン 🎬 が表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ImagePicker
+          onImageSelect={jest.fn()}
+          selectedImage="file:///test/video.mp4"
+          selectedMediaType="video"
+        />,
+      );
+    });
+    const icons = renderer!.root.findAll(el => el.props.children === '🎬');
+    expect(icons.length).toBeGreaterThan(0);
+  });
+
+  it('selectedMediaType=image のとき画像アイコン 🖼️ が表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ImagePicker
+          onImageSelect={jest.fn()}
+          selectedImage="file:///test/image.jpg"
+          selectedMediaType="image"
+        />,
+      );
+    });
+    const icons = renderer!.root.findAll(el => el.props.children === '🖼️');
+    expect(icons.length).toBeGreaterThan(0);
+  });
+
+  it('ボタンの accessibilityRole が "button"', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ImagePicker onImageSelect={jest.fn()} />,
+      );
+    });
+    const buttons = renderer!.root.findAll(
+      node => node.props.accessibilityRole === 'button',
+    );
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it('launchImageLibraryAsync がキャンセルしたとき onImageSelect は呼ばれない', async () => {
+    const onImageSelect = jest.fn();
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ImagePicker onImageSelect={onImageSelect} />,
+      );
+    });
+    const button = renderer!.root.find(
+      node => node.props.accessibilityRole === 'button',
+    );
+    await ReactTestRenderer.act(async () => {
+      await button.props.onPress();
+    });
+    expect(onImageSelect).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/__tests__/ResizeSlider.test.tsx
+++ b/app/src/__tests__/ResizeSlider.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * ResizeSlider コンポーネントのユニットテスト
+ * Issue #191
+ */
+
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+jest.mock('../i18n', () => ({
+  t: (key: string) => key,
+}));
+
+import ResizeSlider from '../components/ResizeSlider';
+
+describe('ResizeSlider', () => {
+  it('originalWidth/Height なしで正常にレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ResizeSlider value={50} onValueChange={jest.fn()} />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('originalWidth/Height ありで解像度タブが表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ResizeSlider
+          value={50}
+          onValueChange={jest.fn()}
+          originalWidth={1920}
+          originalHeight={1080}
+        />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('value=100 でクラッシュしない', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ResizeSlider
+          value={100}
+          onValueChange={jest.fn()}
+          originalWidth={800}
+          originalHeight={600}
+        />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('value=1 でクラッシュしない', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ResizeSlider value={1} onValueChange={jest.fn()} />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('パーセントタブの accessibilityRole が "tab" である', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ResizeSlider value={50} onValueChange={jest.fn()} />,
+      );
+    });
+    const tabs = renderer!.root.findAll(
+      node => node.props.accessibilityRole === 'tab' && typeof node.props.onPress === 'function',
+    );
+    expect(tabs.length).toBeGreaterThan(0);
+  });
+
+  it('初期状態でパーセントタブの accessibilityState.selected が true', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ResizeSlider value={50} onValueChange={jest.fn()} />,
+      );
+    });
+    const percentTab = renderer!.root.findAll(
+      node => node.props.accessibilityRole === 'tab' && typeof node.props.onPress === 'function',
+    )[0];
+    expect(percentTab.props.accessibilityState).toEqual(
+      expect.objectContaining({selected: true}),
+    );
+  });
+
+  it('originalWidth/Height あり: 解像度タブの accessibilityRole が "tab"', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ResizeSlider
+          value={50}
+          onValueChange={jest.fn()}
+          originalWidth={1920}
+          originalHeight={1080}
+        />,
+      );
+    });
+    const resolutionTab = renderer!.root.findAll(
+      node =>
+        node.props.accessibilityRole === 'tab' &&
+        node.props.accessibilityLabel === 'resizeResolutionTab',
+    );
+    expect(resolutionTab.length).toBeGreaterThan(0);
+  });
+
+  it('タブ切り替え後に selected が更新される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <ResizeSlider
+          value={50}
+          onValueChange={jest.fn()}
+          originalWidth={1920}
+          originalHeight={1080}
+        />,
+      );
+    });
+    const instance = renderer!.root;
+    const findPercentTab = () =>
+      instance.findAll(
+        node =>
+          node.props.accessibilityRole === 'tab' &&
+          node.props.accessibilityLabel === 'resizePercentTab',
+      )[0];
+    const findResolutionTab = () =>
+      instance.findAll(
+        node =>
+          node.props.accessibilityRole === 'tab' &&
+          node.props.accessibilityLabel === 'resizeResolutionTab',
+      )[0];
+
+    expect(findPercentTab().props.accessibilityState).toEqual(
+      expect.objectContaining({selected: true}),
+    );
+    expect(findResolutionTab().props.accessibilityState).toEqual(
+      expect.objectContaining({selected: false}),
+    );
+
+    await ReactTestRenderer.act(() => {
+      findResolutionTab().props.onPress();
+    });
+
+    expect(findPercentTab().props.accessibilityState).toEqual(
+      expect.objectContaining({selected: false}),
+    );
+    expect(findResolutionTab().props.accessibilityState).toEqual(
+      expect.objectContaining({selected: true}),
+    );
+  });
+});


### PR DESCRIPTION
## 概要
Closes #191

## 変更内容
- `app/src/__tests__/ResizeSlider.test.tsx` 追加: 初期レンダリング・タブ切り替え・accessibilityState・value境界値のテスト
- `app/src/__tests__/ImagePicker.test.tsx` 追加: メディアタイプアイコン・accessibilityRole・キャンセル時コールバック不呼び出しのテスト

## テスト
CI (Jest) で確認予定