### PR TITLE
test: AboutModal・PreviewCard・ImageInfoBlock・SettingsPanel・TargetSizePanel の個別ユニットテストを追加する

### DIFF
--- a/app/src/__tests__/AboutModal.test.tsx
+++ b/app/src/__tests__/AboutModal.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * AboutModal コンポーネントのユニットテスト
+ * Issue #192
+ */
+
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+jest.mock('../../i18n', () => ({
+  t: (key: string) => key,
+}));
+
+import AboutModal from '../screens/components/AboutModal';
+
+describe('AboutModal', () => {
+  it('visible=true のとき正常にレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <AboutModal visible={true} onClose={jest.fn()} />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('visible=false のとき Modal は閉じた状態でレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <AboutModal visible={false} onClose={jest.fn()} />,
+      );
+    });
+    expect(renderer!.toJSON()).toBeNull();
+  });
+
+  it('"GabiGabi" タイトルが表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <AboutModal visible={true} onClose={jest.fn()} />,
+      );
+    });
+    const texts = renderer!.root.findAll(el => el.props.children === 'GabiGabi');
+    expect(texts.length).toBeGreaterThan(0);
+  });
+
+  it('onClose は閉じるボタン用に渡される', async () => {
+    const onClose = jest.fn();
+    await ReactTestRenderer.act(() => {
+      ReactTestRenderer.create(
+        <AboutModal visible={true} onClose={onClose} />,
+      );
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/__tests__/ImageInfoBlock.test.tsx
+++ b/app/src/__tests__/ImageInfoBlock.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * ImageInfoBlock コンポーネントのユニットテスト
+ * Issue #192
+ */
+
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+jest.mock('../../i18n', () => ({
+  t: (key: string) => key,
+}));
+
+import {BeforeInfoBlock, AfterInfoBlock} from '../screens/components/ImageInfoBlock';
+
+const sampleFileInfo = {
+  name: 'sample.jpg',
+  size: '1.0 MB',
+  width: 1920,
+  height: 1080,
+};
+
+const containsText = (children: unknown, keyword: string): boolean => {
+  if (typeof children === 'string') return children.includes(keyword);
+  if (typeof children === 'number') return String(children).includes(keyword);
+  if (Array.isArray(children)) return children.some(c => containsText(c, keyword));
+  return false;
+};
+
+describe('BeforeInfoBlock', () => {
+  it('ファイル情報が正常にレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <BeforeInfoBlock fileInfo={sampleFileInfo} />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('ファイル名が表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <BeforeInfoBlock fileInfo={sampleFileInfo} />,
+      );
+    });
+    const nameTexts = renderer!.root.findAll(
+      el => containsText(el.props.children, 'sample.jpg'),
+    );
+    expect(nameTexts.length).toBeGreaterThan(0);
+  });
+
+  it('width=0 のとき "0 × 0 px" が表示されない', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <BeforeInfoBlock fileInfo={{...sampleFileInfo, width: 0, height: 0}} />,
+      );
+    });
+    const sizeTexts = renderer!.root.findAll(
+      el => typeof el.props.children === 'string' && el.props.children.includes('0 × 0 px'),
+    );
+    expect(sizeTexts.length).toBe(0);
+  });
+});
+
+describe('AfterInfoBlock', () => {
+  it('processedImage=null のとき正常にレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <AfterInfoBlock
+          fileInfo={sampleFileInfo}
+          processedImage={null}
+          outputBytesFormatted="0.5 MB"
+          resizePercent={100}
+          outputFormat="jpeg"
+          showAfterConversion="変換後に表示"
+        />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('processedImage あり のとき出力ファイル名が表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <AfterInfoBlock
+          fileInfo={sampleFileInfo}
+          processedImage="file:///cache/output.webp"
+          outputBytesFormatted="0.3 MB"
+          resizePercent={50}
+          outputFormat="webp"
+          showAfterConversion="変換後に表示"
+        />,
+      );
+    });
+    const nameTexts = renderer!.root.findAll(
+      el => containsText(el.props.children, 'output.webp'),
+    );
+    expect(nameTexts.length).toBeGreaterThan(0);
+  });
+
+  it('resizePercent=50 のとき解像度が半分に計算される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <AfterInfoBlock
+          fileInfo={sampleFileInfo}
+          processedImage="file:///cache/output.jpg"
+          outputBytesFormatted="0.5 MB"
+          resizePercent={50}
+          outputFormat="jpeg"
+          showAfterConversion="変換後に表示"
+        />,
+      );
+    });
+    // 1920 * 50 / 100 = 960
+    const sizeTexts = renderer!.root.findAll(
+      el => containsText(el.props.children, '960'),
+    );
+    expect(sizeTexts.length).toBeGreaterThan(0);
+  });
+});

--- a/app/src/__tests__/PreviewCard.test.tsx
+++ b/app/src/__tests__/PreviewCard.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * PreviewCard コンポーネントのユニットテスト
+ * Issue #192
+ */
+
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+jest.mock('../../i18n', () => ({
+  t: (key: string) => key,
+}));
+
+jest.mock('react-native-svg', () => {
+  const React = require('react');
+  return {
+    Svg: ({children}: {children: React.ReactNode}) => React.createElement('Svg', null, children),
+    Path: () => null,
+    Rect: () => null,
+    G: () => null,
+  };
+});
+
+import PreviewCard from '../screens/components/PreviewCard';
+
+describe('PreviewCard', () => {
+  it('uri=null のとき空のピッカーボタンがレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <PreviewCard
+          label="変換前"
+          uri={null}
+          placeholder="画像を選択"
+          onPickerPress={jest.fn()}
+        />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('uri あり・image タイプのとき正常にレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <PreviewCard
+          label="変換前"
+          uri="file:///test/image.jpg"
+          mediaType="image"
+          placeholder=""
+          onPickerPress={jest.fn()}
+          onImagePress={jest.fn()}
+        />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('uri あり・video タイプのとき 🎬 アイコンが表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <PreviewCard
+          label="変換後"
+          uri="file:///test/video.mp4"
+          mediaType="video"
+          placeholder=""
+        />,
+      );
+    });
+    const icons = renderer!.root.findAll(el => el.props.children === '🎬');
+    expect(icons.length).toBeGreaterThan(0);
+  });
+
+  it('label テキストが表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <PreviewCard
+          label="変換前"
+          uri={null}
+          placeholder="選択"
+          onPickerPress={jest.fn()}
+        />,
+      );
+    });
+    const labels = renderer!.root.findAll(el => el.props.children === '変換前');
+    expect(labels.length).toBeGreaterThan(0);
+  });
+});

--- a/app/src/__tests__/SettingsPanel.test.tsx
+++ b/app/src/__tests__/SettingsPanel.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * SettingsPanel コンポーネントのユニットテスト
+ * Issue #192
+ */
+
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+jest.mock('../../i18n', () => ({
+  t: (key: string) => key,
+}));
+
+import SettingsPanel from '../screens/components/SettingsPanel';
+
+const defaultProps = {
+  selectedMediaType: null as 'image' | 'video' | null,
+  outputFormat: 'jpeg' as const,
+  videoOutputFormat: 'mp4' as const,
+  compressionRate: 72,
+  resizePercent: 80,
+  gabigabiLevel: null as number | null,
+  shrinkExpandEnabled: false,
+  shrinkExpandRate: 50,
+  multiCompressEnabled: false,
+  multiCompressCount: 3,
+  fileInfoWidth: undefined as number | undefined,
+  fileInfoHeight: undefined as number | undefined,
+  gifFps: 15,
+  gifScale: 100,
+  onOutputFormatChange: jest.fn(),
+  onVideoOutputFormatChange: jest.fn(),
+  onQualityChange: jest.fn(),
+  onResizeChange: jest.fn(),
+  onTemplateSelect: jest.fn(),
+  onShrinkExpandToggle: jest.fn(),
+  onShrinkExpandRateChange: jest.fn(),
+  onMultiCompressToggle: jest.fn(),
+  onMultiCompressCountChange: jest.fn(),
+  onGifFpsChange: jest.fn(),
+  onGifScaleChange: jest.fn(),
+};
+
+describe('SettingsPanel', () => {
+  it('デフォルト props で正常にレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <SettingsPanel {...defaultProps} />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('selectedMediaType=image のとき JPEG フォーマットボタンが表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <SettingsPanel {...defaultProps} selectedMediaType="image" />,
+      );
+    });
+    const jpegButtons = renderer!.root.findAll(el => el.props.children === 'JPEG');
+    expect(jpegButtons.length).toBeGreaterThan(0);
+  });
+
+  it('selectedMediaType=video のとき MP4 フォーマットボタンが表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <SettingsPanel {...defaultProps} selectedMediaType="video" />,
+      );
+    });
+    const mp4Buttons = renderer!.root.findAll(el => el.props.children === 'MP4');
+    expect(mp4Buttons.length).toBeGreaterThan(0);
+  });
+
+  it('shrinkExpandEnabled=true でクラッシュしない', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <SettingsPanel {...defaultProps} shrinkExpandEnabled={true} />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('multiCompressEnabled=true でクラッシュしない', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <SettingsPanel {...defaultProps} multiCompressEnabled={true} />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('gabigabiLevel=3 でクラッシュしない', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <SettingsPanel {...defaultProps} gabigabiLevel={3} />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+});

--- a/app/src/__tests__/TargetSizePanel.test.tsx
+++ b/app/src/__tests__/TargetSizePanel.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * TargetSizePanel コンポーネントのユニットテスト
+ * Issue #192
+ */
+
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+jest.mock('../../i18n', () => ({
+  t: (key: string) => key,
+}));
+
+import TargetSizePanel from '../screens/components/TargetSizePanel';
+
+const defaultProps = {
+  targetSizeValue: '10',
+  targetSizeUnit: 'MB' as const,
+  onValueChange: jest.fn(),
+  onUnitChange: jest.fn(),
+};
+
+describe('TargetSizePanel', () => {
+  it('デフォルト props で正常にレンダリングされる', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <TargetSizePanel {...defaultProps} />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('KB / MB / GB ユニットボタンが表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <TargetSizePanel {...defaultProps} />,
+      );
+    });
+    const kbButtons = renderer!.root.findAll(el => el.props.children === 'KB');
+    const mbButtons = renderer!.root.findAll(el => el.props.children === 'MB');
+    const gbButtons = renderer!.root.findAll(el => el.props.children === 'GB');
+    expect(kbButtons.length).toBeGreaterThan(0);
+    expect(mbButtons.length).toBeGreaterThan(0);
+    expect(gbButtons.length).toBeGreaterThan(0);
+  });
+
+  it('targetSizeValue が TextInput に表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <TargetSizePanel {...defaultProps} targetSizeValue="25" />,
+      );
+    });
+    const inputs = renderer!.root.findAll(el => el.props.value === '25');
+    expect(inputs.length).toBeGreaterThan(0);
+  });
+
+  it('Discord 10MB テンプレートボタンが表示される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <TargetSizePanel {...defaultProps} />,
+      );
+    });
+    const templates = renderer!.root.findAll(el => el.props.children === 'Discord 10MB');
+    expect(templates.length).toBeGreaterThan(0);
+  });
+
+  it('targetSizeUnit=KB でクラッシュしない', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <TargetSizePanel {...defaultProps} targetSizeUnit="KB" />,
+      );
+    });
+    expect(renderer!.toJSON()).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要
Closes #192

## 変更内容
- `app/src/__tests__/AboutModal.test.tsx` 追加: 表示/非表示・タイトル・コールバックのテスト
- `app/src/__tests__/PreviewCard.test.tsx` 追加: uri null/画像/動画・ラベル表示のテスト
- `app/src/__tests__/ImageInfoBlock.test.tsx` 追加: BeforeInfoBlock・AfterInfoBlock のファイル情報・解像度計算のテスト
- `app/src/__tests__/SettingsPanel.test.tsx` 追加: メディアタイプ別フォーマット選択・各フラグのテスト
- `app/src/__tests__/TargetSizePanel.test.tsx` 追加: ユニットボタン・テンプレート・TextInput 値のテスト

## テスト
CI (Jest) で確認予定