### PR TITLE
a11y: SettingsPanel の出力フォーマット選択ボタンに accessibilityState を追加

### DIFF
--- a/app/src/__tests__/SettingsPanel.test.tsx
+++ b/app/src/__tests__/SettingsPanel.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 
-jest.mock('../../i18n', () => ({
+jest.mock('../i18n', () => ({
   t: (key: string) => key,
 }));
 
@@ -101,5 +101,44 @@ describe('SettingsPanel', () => {
       );
     });
     expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('選択中の出力フォーマットボタンに accessibilityState={{selected: true}} が設定される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <SettingsPanel {...defaultProps} selectedMediaType="image" outputFormat="png" />,
+      );
+    });
+    const pngButton = renderer!.root.find(
+      el => el.props.accessibilityLabel === 'outputFormatAccessibility PNG',
+    );
+    expect(pngButton.props.accessibilityState).toEqual({selected: true});
+  });
+
+  it('非選択の出力フォーマットボタンに accessibilityState={{selected: false}} が設定される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <SettingsPanel {...defaultProps} selectedMediaType="image" outputFormat="png" />,
+      );
+    });
+    const jpegButton = renderer!.root.find(
+      el => el.props.accessibilityLabel === 'outputFormatAccessibility JPEG',
+    );
+    expect(jpegButton.props.accessibilityState).toEqual({selected: false});
+  });
+
+  it('選択中の動画フォーマットボタンに accessibilityState={{selected: true}} が設定される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <SettingsPanel {...defaultProps} selectedMediaType="video" videoOutputFormat="mov" />,
+      );
+    });
+    const movButton = renderer!.root.find(
+      el => el.props.accessibilityLabel === 'outputFormatAccessibility MOV',
+    );
+    expect(movButton.props.accessibilityState).toEqual({selected: true});
   });
 });

--- a/app/src/screens/components/SettingsPanel.tsx
+++ b/app/src/screens/components/SettingsPanel.tsx
@@ -144,7 +144,10 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
                   sharedStyles.formatButton,
                   videoOutputFormat === opt.value && sharedStyles.formatButtonActive,
                 ]}
-                onPress={() => onVideoOutputFormatChange(opt.value)}>
+                onPress={() => onVideoOutputFormatChange(opt.value)}
+                accessibilityRole="button"
+                accessibilityLabel={`${t('outputFormatAccessibility')} ${opt.label}`}
+                accessibilityState={{selected: videoOutputFormat === opt.value}}>
                 <Text
                   style={[
                     sharedStyles.formatButtonText,
@@ -172,7 +175,8 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 ]}
                 onPress={() => onOutputFormatChange(opt.value)}
                 accessibilityRole="button"
-                accessibilityLabel={`${t('outputFormatAccessibility')} ${opt.label}`}>
+                accessibilityLabel={`${t('outputFormatAccessibility')} ${opt.label}`}
+                accessibilityState={{selected: outputFormat === opt.value}}>
                 <Text
                   style={[
                     sharedStyles.formatButtonText,


### PR DESCRIPTION
Closes #199

## 変更内容
- 画像フォーマットボタン（JPEG/PNG/WebP/BMP/GIF）に `accessibilityState={{selected}}` を追加
- 動画フォーマットボタン（MP4/MOV/MKV/WebM）に `accessibilityRole`, `accessibilityLabel`, `accessibilityState={{selected}}` を追加
- `jest.mock` のパスを `../../i18n` から `../i18n` に修正（テスト実行エラー解消）
- accessibilityState の検証テスト3件を追加（合計9件パス）