### PR TITLE
a11y: TargetSizePanel の TextInput・ユニットボタン・テンプレートボタンにアクセシビリティ属性を追加

### DIFF
--- a/app/src/__tests__/TargetSizePanel.test.tsx
+++ b/app/src/__tests__/TargetSizePanel.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 
-jest.mock('../../i18n', () => ({
+jest.mock('../i18n', () => ({
   t: (key: string) => key,
 }));
 
@@ -75,5 +75,57 @@ describe('TargetSizePanel', () => {
       );
     });
     expect(renderer!.toJSON()).not.toBeNull();
+  });
+
+  it('MB ユニットボタンに accessibilityState={{selected: true}} が設定される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <TargetSizePanel {...defaultProps} targetSizeUnit="MB" />,
+      );
+    });
+    const mbButton = renderer!.root.find(
+      el => el.props.accessibilityLabel === 'unitButtonAccessibility MB',
+    );
+    expect(mbButton.props.accessibilityState).toEqual({selected: true});
+  });
+
+  it('非選択の KB ユニットボタンに accessibilityState={{selected: false}} が設定される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <TargetSizePanel {...defaultProps} targetSizeUnit="MB" />,
+      );
+    });
+    const kbButton = renderer!.root.find(
+      el => el.props.accessibilityLabel === 'unitButtonAccessibility KB',
+    );
+    expect(kbButton.props.accessibilityState).toEqual({selected: false});
+  });
+
+  it('TextInput に accessibilityLabel が設定される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <TargetSizePanel {...defaultProps} />,
+      );
+    });
+    const input = renderer!.root.find(
+      el => el.props.accessibilityLabel === 'targetSizeInputAccessibility',
+    );
+    expect(input).toBeTruthy();
+  });
+
+  it('テンプレートボタンに accessibilityRole="button" が設定される', async () => {
+    let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+    await ReactTestRenderer.act(() => {
+      renderer = ReactTestRenderer.create(
+        <TargetSizePanel {...defaultProps} />,
+      );
+    });
+    const discordBtn = renderer!.root.find(
+      el => el.props.accessibilityLabel === 'templateButtonAccessibility Discord 10MB',
+    );
+    expect(discordBtn.props.accessibilityRole).toBe('button');
   });
 });

--- a/app/src/screens/components/TargetSizePanel.tsx
+++ b/app/src/screens/components/TargetSizePanel.tsx
@@ -40,13 +40,18 @@ const TargetSizePanel: React.FC<TargetSizePanelProps> = ({
           keyboardType="numeric"
           placeholder="0.0"
           placeholderTextColor="#666"
+          accessibilityLabel={t('targetSizeInputAccessibility')}
+          accessibilityHint={t('targetSizeInputHint')}
         />
         <View style={styles.unitButtons}>
           {(['KB', 'MB', 'GB'] as SizeUnit[]).map(u => (
             <TouchableOpacity
               key={u}
               style={[styles.unitButton, targetSizeUnit === u && styles.unitButtonActive]}
-              onPress={() => onUnitChange(u)}>
+              onPress={() => onUnitChange(u)}
+              accessibilityRole="button"
+              accessibilityLabel={`${t('unitButtonAccessibility')} ${u}`}
+              accessibilityState={{selected: targetSizeUnit === u}}>
               <Text style={[styles.unitButtonText, targetSizeUnit === u && styles.unitButtonTextActive]}>{u}</Text>
             </TouchableOpacity>
           ))}
@@ -59,7 +64,9 @@ const TargetSizePanel: React.FC<TargetSizePanelProps> = ({
           <TouchableOpacity
             key={tmpl.label}
             style={styles.targetSizeTemplate}
-            onPress={() => handleTemplateSelect(tmpl)}>
+            onPress={() => handleTemplateSelect(tmpl)}
+            accessibilityRole="button"
+            accessibilityLabel={`${t('templateButtonAccessibility')} ${tmpl.label}`}>
             <Text style={styles.targetSizeTemplateText}>{tmpl.label}</Text>
           </TouchableOpacity>
         ))}


### PR DESCRIPTION
Closes #198

## 変更内容
- `TextInput` に `accessibilityLabel` / `accessibilityHint` を追加
- ユニットボタン（KB/MB/GB）に `accessibilityRole`, `accessibilityLabel`, `accessibilityState={{selected}}` を追加
- テンプレートボタン（Discord 10MB など）に `accessibilityRole`, `accessibilityLabel` を追加
- `jest.mock` のパスを `../i18n` に修正
- アクセシビリティ検証テスト4件を追加（合計9件パス）