### PR TITLE
fix: AboutModal・ImageInfoBlock・PreviewCard テストの jest.mock パスを修正（../../i18n → ../i18n）

### DIFF
--- a/app/src/__tests__/AboutModal.test.tsx
+++ b/app/src/__tests__/AboutModal.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 
-jest.mock('../../i18n', () => ({
+jest.mock('../i18n', () => ({
   t: (key: string) => key,
 }));
 

--- a/app/src/__tests__/ImageInfoBlock.test.tsx
+++ b/app/src/__tests__/ImageInfoBlock.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 
-jest.mock('../../i18n', () => ({
+jest.mock('../i18n', () => ({
   t: (key: string) => key,
 }));
 

--- a/app/src/__tests__/PreviewCard.test.tsx
+++ b/app/src/__tests__/PreviewCard.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 
-jest.mock('../../i18n', () => ({
+jest.mock('../i18n', () => ({
   t: (key: string) => key,
 }));
 


### PR DESCRIPTION
fixes #204

## 変更内容

`src/__tests__/` から `src/i18n.ts` への相対パスが誤っていたため、テストスイートが実行時エラーで失敗していた。

- `../../i18n` → `../i18n` に修正

## 対象ファイル

- `app/src/__tests__/AboutModal.test.tsx`
- `app/src/__tests__/ImageInfoBlock.test.tsx`
- `app/src/__tests__/PreviewCard.test.tsx`