### PR TITLE
test: CustomSlider の accessibilityValue 属性をユニットテストで検証する (#206)

### DIFF
--- a/app/src/__tests__/CustomSlider.test.tsx
+++ b/app/src/__tests__/CustomSlider.test.tsx
@@ -42,6 +42,51 @@ describe('CustomSlider', () => {
       expect(container.length).toBeGreaterThan(0);
     });
 
+    it('accessibilityValue に min/max/now が反映される', async () => {
+      let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+      await ReactTestRenderer.act(() => {
+        renderer = ReactTestRenderer.create(
+          <CustomSlider
+            minimumValue={0}
+            maximumValue={200}
+            value={75}
+            onValueChange={jest.fn()}
+          />,
+        );
+      });
+      const instance = renderer!.root;
+      const el = instance.find(e => e.props.accessibilityRole === 'adjustable');
+      expect(el.props.accessibilityValue).toEqual({min: 0, max: 200, now: 75});
+    });
+
+    it('値が変更されると accessibilityValue.now が更新される', async () => {
+      let renderer: ReactTestRenderer.ReactTestRenderer | undefined;
+      const onValueChange = jest.fn();
+      await ReactTestRenderer.act(() => {
+        renderer = ReactTestRenderer.create(
+          <CustomSlider
+            minimumValue={0}
+            maximumValue={100}
+            value={30}
+            onValueChange={onValueChange}
+          />,
+        );
+      });
+      await ReactTestRenderer.act(() => {
+        renderer!.update(
+          <CustomSlider
+            minimumValue={0}
+            maximumValue={100}
+            value={80}
+            onValueChange={onValueChange}
+          />,
+        );
+      });
+      const instance = renderer!.root;
+      const el = instance.find(e => e.props.accessibilityRole === 'adjustable');
+      expect(el.props.accessibilityValue).toEqual({min: 0, max: 100, now: 80});
+    });
+
     it('accessibilityLabel が props から反映される', async () => {
       const label = 'リサイズスライダー';
       let renderer: ReactTestRenderer.ReactTestRenderer | undefined;

--- a/app/src/components/CustomSlider.tsx
+++ b/app/src/components/CustomSlider.tsx
@@ -86,6 +86,7 @@ const CustomSlider: React.FC<CustomSliderProps> = ({
       accessibilityRole="adjustable"
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}
+      accessibilityValue={{min: minimumValue, max: maximumValue, now: value}}
       {...panResponder.panHandlers}>
       <View style={styles.track}>
         <View style={[styles.trackFill, {flex: ratio, backgroundColor: minimumTrackTintColor}]} />


### PR DESCRIPTION
Closes #206

## 変更内容

- `CustomSlider` コンポーネントに `accessibilityValue` (`min`/`max`/`now`) プロパティを追加
- `accessibilityValue` に min/max/now が正しく設定されることを検証するテストを追加
- 値変更時に `accessibilityValue.now` が更新されることを検証するテストを追加

これにより issue #198〜#200 系の a11y 対応と整合性が保たれ、アクセシビリティ属性のリグレッション防止に貢献する。