### PR TITLE
fix: FfmpegCompressor テストで buildFfmpegCommand が関数として認識されない問題を修正 (#208)

### DIFF
--- a/app/src/__tests__/FfmpegCompressor.test.ts
+++ b/app/src/__tests__/FfmpegCompressor.test.ts
@@ -1,4 +1,4 @@
-import { compressForDiscord, compressToTargetSize } from '../data/ffmpeg/FfmpegCompressor';
+import { compressForDiscord, compressToTargetSize, resetH264CodecCache } from '../data/ffmpeg/FfmpegCompressor';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -46,6 +46,9 @@ jest.mock('../data/ffmpeg/ffmpegUtils', () => ({
     path: `/cache/${stem}_${suffix}`,
   })),
   getFileSizeBytes: jest.fn().mockImplementation((info: { size?: number }) => info?.size ?? 0),
+  buildFfmpegCommand: jest.fn().mockImplementation((parts: Array<string | number | null | undefined>) =>
+    parts.filter((p) => p != null).join(' ')
+  ),
 }));
 
 // ---------------------------------------------------------------------------
@@ -69,6 +72,9 @@ function setupSuccessSession() {
     path: `/cache/${stem}_${suffix}`,
   }));
   ffmpegUtils.getFileSizeBytes.mockImplementation((info: { size?: number }) => info?.size ?? 0);
+  ffmpegUtils.buildFfmpegCommand.mockImplementation((parts: Array<string | number | null | undefined>) =>
+    parts.filter((p) => p != null).join(' ')
+  );
   ReturnCode.isSuccess.mockReturnValue(true);
   mockGetReturnCode.mockResolvedValue({});
   mockExecute.mockResolvedValue({
@@ -184,6 +190,7 @@ describe('compressForDiscord (image)', () => {
 describe('compressForDiscord (video)', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    resetH264CodecCache();
     mockReadDirectoryAsync.mockResolvedValue([]);
     mockDeleteAsync.mockResolvedValue(undefined);
     setupSuccessSession();
@@ -269,11 +276,10 @@ describe('compressForDiscord (video)', () => {
     });
 
     mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 50 * 1024 * 1024 })
-      .mockResolvedValueOnce({ exists: true })
-      .mockResolvedValueOnce({ exists: true, size: 20 * 1024 * 1024 })
-      .mockResolvedValueOnce({ exists: true, size: 18 * 1024 * 1024 })
-      .mockResolvedValueOnce({ exists: true, size: 9 * 1024 * 1024 });
+      .mockResolvedValueOnce({ exists: true, size: 50 * 1024 * 1024 })  // 1. input
+      .mockResolvedValueOnce({ exists: true, size: 20 * 1024 * 1024 }) // 2. CRF出力（目標超過→2パスへ）
+      .mockResolvedValueOnce({ exists: true, size: 18 * 1024 * 1024 }) // 3. 2パス後出力（目標超過→リトライ）
+      .mockResolvedValueOnce({ exists: true, size: 9 * 1024 * 1024 });  // 4. リトライ後出力（目標以下）
 
     await compressToTargetSize('file:///videos/clip.mp4', target);
 
@@ -294,6 +300,7 @@ describe('compressForDiscord (video)', () => {
 describe('compressToTargetSize', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    resetH264CodecCache();
     mockReadDirectoryAsync.mockResolvedValue([]);
     mockDeleteAsync.mockResolvedValue(undefined);
     setupSuccessSession();

--- a/app/src/__tests__/ffmpegUtils.test.ts
+++ b/app/src/__tests__/ffmpegUtils.test.ts
@@ -30,7 +30,16 @@ jest.mock('expo-file-system/legacy', () => ({
   deleteAsync: jest.fn(),
 }));
 
-describe('generateUniqueFileSuffix', () => {
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+  removeItem: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../data/history/conversionHistory', () => ({
+  getConversionHistory: jest.fn().mockResolvedValue([]),
+}));
+('generateUniqueFileSuffix', () => {
   it('returns a non-empty string', () => {
     const suffix = generateUniqueFileSuffix();
     expect(typeof suffix).toBe('string');

--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -444,3 +444,6 @@ export async function compressToTargetSize(
   }
 }
 
+
+/** @internal テスト用 — コーデックキャッシュをリセットする */
+export function resetH264CodecCache(): void { cachedH264Codec = null; }


### PR DESCRIPTION
## 概要

Issue #208 で報告された `FfmpegCompressor.test.ts` の全テスト失敗を修正する。

## 原因

`ffmpegUtils` のモックに `buildFfmpegCommand` が含まれていなかったため、全テストが `TypeError: (0 , _ffmpegUtils.buildFfmpegCommand) is not a function` で失敗していた。

加えて、`ffmpegUtils.test.ts` では `conversionHistory` → `AsyncStorage` の依存チェーンのモックが欠けていた。

## 変更内容

- `FfmpegCompressor.test.ts`
  - `ffmpegUtils` モックに `buildFfmpegCommand` を追加
  - 動画テストの `beforeEach` で `resetH264CodecCache()` を呼び出し、コーデックキャッシュを初期化（テスト間の `execute` 呼び出し順序の安定化）
  - リトライビットレート計算テストの `getInfoAsync` モック設定を実際の呼び出し順序に合わせて修正（不要な「cache dir」エントリを削除）
- `ffmpegUtils.test.ts`
  - `@react-native-async-storage/async-storage` と `conversionHistory` のモックを追加
- `FfmpegCompressor.ts`
  - テスト用キャッシュリセット関数 `resetH264CodecCache()` を export

## テスト結果

修正前: 13テスト全失敗  
修正後: 13テスト全PASS

Closes #208