### PR TITLE
test: App.test.tsx のネイティブモジュールモックを整備して統合テストを有効化する

### DIFF
--- a/app/__tests__/App.test.tsx
+++ b/app/__tests__/App.test.tsx
@@ -3,10 +3,149 @@
  * @jest-environment node
  */
 
-/**
- * App.test.tsx は expo/RN ネイティブモジュールへの深い依存があるため
- * 現時点ではスキップし、個別コンポーネントのユニットテストで品質を担保する。
- * TODO: jest.setup.js でグローバルモックを整備した後に有効化する
- */
+import React from 'react';
 
-test.todo('App renders correctly');
+// ネイティブモジュールのモック（jest.mock はホイスティングが必要なため test ファイルに記述）
+jest.mock('expo-modules-core', () => ({
+  NativeModulesProxy: {},
+  EventEmitter: class EventEmitter {
+    addListener() { return {remove: () => {}}; }
+    removeListener() {}
+    emit() {}
+    removeAllListeners() {}
+    listenerCount() { return 0; }
+  },
+  requireNativeModule: jest.fn(() => ({})),
+  requireOptionalNativeModule: jest.fn(() => null),
+  SharedObject: class SharedObject {},
+}));
+
+jest.mock('expo-file-system', () => ({
+  documentDirectory: 'file:///mock/documents/',
+  cacheDirectory: 'file:///mock/cache/',
+  readAsStringAsync: jest.fn().mockResolvedValue(''),
+  writeAsStringAsync: jest.fn().mockResolvedValue(undefined),
+  deleteAsync: jest.fn().mockResolvedValue(undefined),
+  moveAsync: jest.fn().mockResolvedValue(undefined),
+  copyAsync: jest.fn().mockResolvedValue(undefined),
+  makeDirectoryAsync: jest.fn().mockResolvedValue(undefined),
+  readDirectoryAsync: jest.fn().mockResolvedValue([]),
+  getInfoAsync: jest.fn().mockResolvedValue({exists: false, isDirectory: false}),
+  downloadAsync: jest.fn().mockResolvedValue({uri: '', status: 200}),
+  EncodingType: {UTF8: 'utf8', Base64: 'base64'},
+}));
+
+jest.mock('expo-file-system/legacy', () => ({
+  documentDirectory: 'file:///mock/documents/',
+  cacheDirectory: 'file:///mock/cache/',
+  readAsStringAsync: jest.fn().mockResolvedValue(''),
+  writeAsStringAsync: jest.fn().mockResolvedValue(undefined),
+  deleteAsync: jest.fn().mockResolvedValue(undefined),
+  moveAsync: jest.fn().mockResolvedValue(undefined),
+  copyAsync: jest.fn().mockResolvedValue(undefined),
+  makeDirectoryAsync: jest.fn().mockResolvedValue(undefined),
+  readDirectoryAsync: jest.fn().mockResolvedValue([]),
+  getInfoAsync: jest.fn().mockResolvedValue({exists: false, isDirectory: false}),
+  downloadAsync: jest.fn().mockResolvedValue({uri: '', status: 200}),
+  EncodingType: {UTF8: 'utf8', Base64: 'base64'},
+}));
+
+jest.mock('ffmpeg-kit-react-native', () => ({
+  FFmpegKit: {
+    execute: jest.fn().mockResolvedValue({
+      getReturnCode: jest.fn().mockResolvedValue({
+        isValueSuccess: jest.fn().mockReturnValue(true),
+      }),
+    }),
+    executeAsync: jest.fn().mockResolvedValue({}),
+    cancel: jest.fn(),
+    cancelSession: jest.fn(),
+    listSessions: jest.fn().mockResolvedValue([]),
+  },
+  FFmpegKitConfig: {
+    enableLogCallback: jest.fn(),
+    enableStatisticsCallback: jest.fn(),
+    setLogLevel: jest.fn(),
+    resetStatistics: jest.fn(),
+  },
+  ReturnCode: {
+    isSuccess: jest.fn().mockReturnValue(true),
+    isCancel: jest.fn().mockReturnValue(false),
+    SUCCESS: 0,
+  },
+  LogLevel: {INFO: 0, AV_LOG_STDERR: 16},
+}));
+
+jest.mock('expo-media-library', () => ({
+  requestPermissionsAsync: jest.fn().mockResolvedValue({status: 'granted'}),
+  saveToLibraryAsync: jest.fn().mockResolvedValue(undefined),
+  getPermissionsAsync: jest.fn().mockResolvedValue({status: 'granted'}),
+  MediaType: {video: 'video', photo: 'photo'},
+  createAlbumAsync: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('expo-image-picker', () => ({
+  launchImageLibraryAsync: jest.fn().mockResolvedValue({canceled: true, assets: []}),
+  requestMediaLibraryPermissionsAsync: jest.fn().mockResolvedValue({status: 'granted'}),
+  MediaTypeOptions: {All: 'All', Images: 'Images', Videos: 'Videos'},
+}));
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn().mockResolvedValue(undefined),
+  getStringAsync: jest.fn().mockResolvedValue(''),
+}));
+
+jest.mock('react-native-share', () => ({
+  __esModule: true,
+  default: {
+    open: jest.fn().mockResolvedValue({success: true}),
+    shareSingle: jest.fn().mockResolvedValue({success: true}),
+  },
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const insets = {top: 0, bottom: 0, left: 0, right: 0};
+  const frame = {x: 0, y: 0, width: 375, height: 812};
+  const SafeAreaInsetsContext = React.createContext(insets);
+  const SafeAreaFrameContext = React.createContext(frame);
+  return {
+    useSafeAreaInsets: jest.fn().mockReturnValue(insets),
+    useSafeAreaFrame: jest.fn().mockReturnValue(frame),
+    SafeAreaProvider: ({children, initialMetrics}: any) => {
+      return React.createElement(
+        SafeAreaInsetsContext.Provider,
+        {value: insets},
+        React.createElement(SafeAreaFrameContext.Provider, {value: frame}, children),
+      );
+    },
+    SafeAreaConsumer: SafeAreaInsetsContext.Consumer,
+    SafeAreaView: ({children}: any) => children,
+    SafeAreaInsetsContext,
+    SafeAreaFrameContext,
+    initialWindowMetrics: {frame, insets},
+  };
+});
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+  removeItem: jest.fn().mockResolvedValue(undefined),
+  multiGet: jest.fn().mockResolvedValue([]),
+  multiSet: jest.fn().mockResolvedValue(undefined),
+}));
+
+import {render} from '@testing-library/react-native';
+import {SafeAreaProvider} from 'react-native-safe-area-context';
+import App from '../App';
+
+describe('App', () => {
+  it('renders correctly', () => {
+    const {toJSON} = render(
+      <SafeAreaProvider>
+        <App />
+      </SafeAreaProvider>
+    );
+    expect(toJSON()).not.toBeNull();
+  });
+});

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -6,9 +6,15 @@ module.exports = {
       displayName: 'unit',
       preset: 'react-native',
       transformIgnorePatterns: [
-        'node_modules/(?!(react-native|@react-native|expo|expo-notifications|expo-modules-core|expo-image-picker|expo-media-library|expo-file-system|expo-clipboard|react-native-svg|react-native-share|react-native-safe-area-context|@testing-library|@react-navigation|ffmpeg-kit-react-native)/)',
+        'node_modules/(?!(react-native|@react-native|expo(-[a-z-]+)?|@expo|expo-modules-core|@testing-library|@react-navigation|ffmpeg-kit-react-native|react-native-svg|react-native-share|react-native-safe-area-context)/)',
       ],
       testMatch: ['<rootDir>/__tests__/**/*.test.{ts,tsx}', '<rootDir>/src/__tests__/**/*.test.{ts,tsx}'],
+      moduleNameMapper: {
+        '^expo-notifications$': '<rootDir>/src/__mocks__/expo-notifications.js',
+        '^expo-sharing$': '<rootDir>/src/__mocks__/expo-sharing.js',
+        '^expo-video-thumbnails$': '<rootDir>/src/__mocks__/expo-video-thumbnails.js',
+        '^expo-constants$': '<rootDir>/src/__mocks__/expo-constants.js',
+      },
     },
     {
       displayName: 'integration',

--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -11,3 +11,105 @@ if (!globalThis.expo) {
     NativeModulesProxy: {},
   };
 }
+
+// expo-file-system モック
+jest.mock('expo-file-system', () => ({
+  documentDirectory: 'file:///mock/documents/',
+  cacheDirectory: 'file:///mock/cache/',
+  readAsStringAsync: jest.fn().mockResolvedValue(''),
+  writeAsStringAsync: jest.fn().mockResolvedValue(undefined),
+  deleteAsync: jest.fn().mockResolvedValue(undefined),
+  moveAsync: jest.fn().mockResolvedValue(undefined),
+  copyAsync: jest.fn().mockResolvedValue(undefined),
+  makeDirectoryAsync: jest.fn().mockResolvedValue(undefined),
+  readDirectoryAsync: jest.fn().mockResolvedValue([]),
+  getInfoAsync: jest.fn().mockResolvedValue({exists: false, isDirectory: false}),
+  downloadAsync: jest.fn().mockResolvedValue({uri: '', status: 200}),
+  EncodingType: {UTF8: 'utf8', Base64: 'base64'},
+}));
+
+// expo-file-system/legacy モック
+jest.mock('expo-file-system/legacy', () => ({
+  documentDirectory: 'file:///mock/documents/',
+  cacheDirectory: 'file:///mock/cache/',
+  readAsStringAsync: jest.fn().mockResolvedValue(''),
+  writeAsStringAsync: jest.fn().mockResolvedValue(undefined),
+  deleteAsync: jest.fn().mockResolvedValue(undefined),
+  moveAsync: jest.fn().mockResolvedValue(undefined),
+  copyAsync: jest.fn().mockResolvedValue(undefined),
+  makeDirectoryAsync: jest.fn().mockResolvedValue(undefined),
+  readDirectoryAsync: jest.fn().mockResolvedValue([]),
+  getInfoAsync: jest.fn().mockResolvedValue({exists: false, isDirectory: false}),
+  downloadAsync: jest.fn().mockResolvedValue({uri: '', status: 200}),
+  EncodingType: {UTF8: 'utf8', Base64: 'base64'},
+}));
+
+// expo-modules-core モック
+jest.mock('expo-modules-core', () => ({
+  NativeModulesProxy: {},
+  EventEmitter: class EventEmitter {
+    addListener() { return {remove: () => {}}; }
+    removeListener() {}
+    emit() {}
+    removeAllListeners() {}
+  },
+  requireNativeModule: jest.fn(() => ({})),
+  requireOptionalNativeModule: jest.fn(() => null),
+}));
+
+// ffmpeg-kit-react-native モック
+jest.mock('ffmpeg-kit-react-native', () => ({
+  FFmpegKit: {
+    execute: jest.fn().mockResolvedValue({getReturnCode: jest.fn().mockResolvedValue({isValueSuccess: jest.fn().mockReturnValue(true)})}),
+    executeAsync: jest.fn().mockResolvedValue({}),
+    cancel: jest.fn(),
+  },
+  FFmpegKitConfig: {
+    enableLogCallback: jest.fn(),
+    enableStatisticsCallback: jest.fn(),
+    setLogLevel: jest.fn(),
+  },
+  ReturnCode: {
+    isSuccess: jest.fn().mockReturnValue(true),
+    isCancel: jest.fn().mockReturnValue(false),
+    SUCCESS: 0,
+  },
+  LogLevel: {INFO: 0, AV_LOG_STDERR: 16},
+  Session: {},
+}));
+
+// expo-media-library モック
+jest.mock('expo-media-library', () => ({
+  requestPermissionsAsync: jest.fn().mockResolvedValue({status: 'granted'}),
+  saveToLibraryAsync: jest.fn().mockResolvedValue(undefined),
+  getPermissionsAsync: jest.fn().mockResolvedValue({status: 'granted'}),
+  MediaType: {video: 'video', photo: 'photo'},
+}));
+
+// expo-image-picker モック
+jest.mock('expo-image-picker', () => ({
+  launchImageLibraryAsync: jest.fn().mockResolvedValue({canceled: true, assets: []}),
+  requestMediaLibraryPermissionsAsync: jest.fn().mockResolvedValue({status: 'granted'}),
+  MediaTypeOptions: {All: 'All', Images: 'Images', Videos: 'Videos'},
+}));
+
+// expo-clipboard モック
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn().mockResolvedValue(undefined),
+  getStringAsync: jest.fn().mockResolvedValue(''),
+}));
+
+// react-native-share モック
+jest.mock('react-native-share', () => ({
+  default: {
+    open: jest.fn().mockResolvedValue({success: true}),
+    shareSingle: jest.fn().mockResolvedValue({success: true}),
+  },
+}));
+
+// react-native-safe-area-context モック
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: jest.fn().mockReturnValue({top: 0, bottom: 0, left: 0, right: 0}),
+  SafeAreaProvider: ({children}) => children,
+  SafeAreaView: ({children}) => children,
+}));

--- a/app/src/__mocks__/expo-constants.js
+++ b/app/src/__mocks__/expo-constants.js
@@ -1,0 +1,10 @@
+module.exports = {
+  default: {
+    expoConfig: {name: 'test', slug: 'test'},
+    manifest: {},
+    sessionId: 'mock-session',
+    statusBarHeight: 0,
+    platform: {},
+  },
+  ExecutionEnvironment: {Bare: 'bare', Standalone: 'standalone', StoreClient: 'storeClient'},
+};

--- a/app/src/__mocks__/expo-notifications.js
+++ b/app/src/__mocks__/expo-notifications.js
@@ -1,0 +1,15 @@
+module.exports = {
+  requestPermissionsAsync: jest.fn().mockResolvedValue({status: 'granted'}),
+  getPermissionsAsync: jest.fn().mockResolvedValue({status: 'granted'}),
+  scheduleNotificationAsync: jest.fn().mockResolvedValue('mock-id'),
+  cancelScheduledNotificationAsync: jest.fn().mockResolvedValue(undefined),
+  cancelAllScheduledNotificationsAsync: jest.fn().mockResolvedValue(undefined),
+  setNotificationHandler: jest.fn(),
+  addNotificationReceivedListener: jest.fn().mockReturnValue({remove: jest.fn()}),
+  addNotificationResponseReceivedListener: jest.fn().mockReturnValue({remove: jest.fn()}),
+  AndroidImportance: {DEFAULT: 3, HIGH: 4, LOW: 2, MAX: 5, MIN: 1, NONE: 0},
+  IosAlertStyle: {ALERT: 'alert', BADGE: 'badge', SOUND: 'sound'},
+  setNotificationChannelAsync: jest.fn().mockResolvedValue(null),
+  getExpoPushTokenAsync: jest.fn().mockResolvedValue({data: 'mock-token'}),
+  useLastNotificationResponse: jest.fn().mockReturnValue(null),
+};

--- a/app/src/__mocks__/expo-sharing.js
+++ b/app/src/__mocks__/expo-sharing.js
@@ -1,0 +1,4 @@
+module.exports = {
+  isAvailableAsync: jest.fn().mockResolvedValue(true),
+  shareAsync: jest.fn().mockResolvedValue(undefined),
+};

--- a/app/src/__mocks__/expo-video-thumbnails.js
+++ b/app/src/__mocks__/expo-video-thumbnails.js
@@ -1,0 +1,3 @@
+module.exports = {
+  getThumbnailAsync: jest.fn().mockResolvedValue({uri: 'file:///mock/thumbnail.jpg', width: 100, height: 100}),
+};

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1180,6 +1180,25 @@
   dependencies:
     node-forge "^1.3.3"
 
+"@expo/config-plugins@^55.0.8", "@expo/config-plugins@~55.0.6":
+  version "55.0.8"
+  resolved "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz"
+  integrity sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==
+  dependencies:
+    "@expo/config-types" "^55.0.5"
+    "@expo/json-file" "~10.0.13"
+    "@expo/plist" "^0.5.2"
+    "@expo/sdk-runtime-versions" "^1.0.0"
+    chalk "^4.1.2"
+    debug "^4.3.5"
+    getenv "^2.0.0"
+    glob "^13.0.0"
+    resolve-from "^5.0.0"
+    semver "^7.5.4"
+    slugify "^1.6.6"
+    xcode "^3.0.1"
+    xml2js "0.6.0"
+
 "@expo/config-plugins@~54.0.4":
   version "54.0.4"
   resolved "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.4.tgz"
@@ -1196,25 +1215,6 @@
     resolve-from "^5.0.0"
     semver "^7.5.4"
     slash "^3.0.0"
-    slugify "^1.6.6"
-    xcode "^3.0.1"
-    xml2js "0.6.0"
-
-"@expo/config-plugins@~55.0.6":
-  version "55.0.6"
-  resolved "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.6.tgz"
-  integrity sha512-cIox6FjZlFaaX40rbQ3DvP9e87S5X85H9uw+BAxJE5timkMhuByy3GAlOsj1h96EyzSiol7Q6YIGgY1Jiz4M+A==
-  dependencies:
-    "@expo/config-types" "^55.0.5"
-    "@expo/json-file" "~10.0.12"
-    "@expo/plist" "^0.5.2"
-    "@expo/sdk-runtime-versions" "^1.0.0"
-    chalk "^4.1.2"
-    debug "^4.3.5"
-    getenv "^2.0.0"
-    glob "^13.0.0"
-    resolve-from "^5.0.0"
-    semver "^7.5.4"
     slugify "^1.6.6"
     xcode "^3.0.1"
     xml2js "0.6.0"
@@ -1335,10 +1335,10 @@
     resolve-from "^5.0.0"
     semver "^7.6.0"
 
-"@expo/json-file@^10.0.12", "@expo/json-file@^10.0.8", "@expo/json-file@~10.0.12", "@expo/json-file@~10.0.8":
-  version "10.0.12"
-  resolved "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.12.tgz"
-  integrity sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==
+"@expo/json-file@^10.0.12", "@expo/json-file@^10.0.8", "@expo/json-file@~10.0.12", "@expo/json-file@~10.0.13", "@expo/json-file@~10.0.8":
+  version "10.0.14"
+  resolved "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.14.tgz"
+  integrity sha512-yWwBFywFv+SxkJp/pIzzA416JVYflNUh7pqQzgaA6nXDqRyK7KfrqVzk8PdUfDnqbBcaZZxpzNssfQZzp5KHrA==
   dependencies:
     "@babel/code-frame" "^7.20.0"
     json5 "^2.2.3"
@@ -4311,10 +4311,24 @@ expo-server@^55.0.5:
   resolved "https://registry.npmjs.org/expo-server/-/expo-server-55.0.5.tgz"
   integrity sha512-cfoh1OwBjHPCwYD11wep12l5WGkVEmRbGSZEbE4u+08k1TkOyYhrWyI2o/iMcUMMT8u1sKsymHKsrC8Mv82V7A==
 
+expo-sharing@^55.0.18:
+  version "55.0.18"
+  resolved "https://registry.npmjs.org/expo-sharing/-/expo-sharing-55.0.18.tgz"
+  integrity sha512-Tqy4LXRLw/UEg5mT7BKhx8y4ReNz8fVldvhHJV5cesH3kRgEerHkYxVwid2vd7v34KnNp0RH1OqUyDlzZTQ9AQ==
+  dependencies:
+    "@expo/config-plugins" "^55.0.8"
+    "@expo/config-types" "^55.0.5"
+    "@expo/plist" "^0.5.2"
+
 expo-updates-interface@~55.1.3:
   version "55.1.3"
   resolved "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-55.1.3.tgz"
   integrity sha512-UVVIiZqymQZJL+o/jh65kXOI97xdkbqBJJM0LMabaPMNLFnc6/WvOMOzmQs7SPyKb8+0PeBaFd7tj5DzF6JeQg==
+
+expo-video-thumbnails@~55.0.14:
+  version "55.0.14"
+  resolved "https://registry.npmjs.org/expo-video-thumbnails/-/expo-video-thumbnails-55.0.14.tgz"
+  integrity sha512-OeUXzElV/+iXXtzLFgjQKGKRlRh3qcqarEMKBMLQKO4LZ39H8EtJIs+DsEMs/UM9fPe5Xhi5dm2QkNblJQxLtg==
 
 expo@^55.0.2:
   version "55.0.2"


### PR DESCRIPTION
## 概要

Issue #212 の対応として、`App.test.tsx` が `test.todo` でスキップされていたテストを有効化する。

## 変更内容

### jest.setup.js
以下のグローバルモックを追加:
- `expo-file-system` / `expo-file-system/legacy`
- `expo-modules-core`
- `ffmpeg-kit-react-native`
- `expo-media-library`
- `expo-image-picker`
- `expo-clipboard`
- `react-native-share`
- `react-native-safe-area-context`

### app/src/__mocks__/
`moduleNameMapper` で差し替えるモジュールモックを追加:
- `expo-notifications.js`
- `expo-sharing.js`
- `expo-video-thumbnails.js`
- `expo-constants.js`

### jest.config.js
- `transformIgnorePatterns` を全 `expo-*` パッケージに対応するよう更新
- `moduleNameMapper` を追加（`unit` プロジェクト）

### App.test.tsx
- `test.todo` を削除し、実際のレンダリングテストを実装
- `react-native-safe-area-context` の Context を正しく提供するモックを追加

## テスト確認

```
PASS unit __tests__/App.test.tsx
  App
    ✓ renders correctly (5218 ms)
```

Closes #212