### PR TITLE
refactor: compressToTargetSize / compressForDiscord の videoFormat パラメータを VideoFormat 型に厳格化

### DIFF
--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -1,6 +1,7 @@
 import { FFmpegKit, FFprobeKit, ReturnCode } from 'ffmpeg-kit-react-native';
 import * as FileSystem from 'expo-file-system/legacy';
 import { buildFfmpegCommand, generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getPasslogConfig, getFileSizeBytes } from './ffmpegUtils';
+import { VideoFormat } from '../../state/store';
 import { DISCORD_MAX_BYTES } from '../../constants/limits';
 
 export interface CompressResult {
@@ -171,7 +172,7 @@ async function compressImageToTarget(
 async function compressVideoToTarget(
   inputUri: string,
   targetBytes: number,
-  outputFormat: string = 'mp4',
+  outputFormat: VideoFormat = 'mp4',
 ): Promise<CompressResult> {
   // 入力ファイルの存在確認とサイズチェック
   const inputInfo = await FileSystem.getInfoAsync(inputUri, { size: true });
@@ -415,7 +416,7 @@ async function compressVideoToTarget(
  */
 export async function compressForDiscord(
   inputUri: string,
-  videoFormat: string = 'mp4',
+  videoFormat: VideoFormat = 'mp4',
 ): Promise<CompressResult> {
   if (isVideoFile(inputUri)) {
     return compressVideoToTarget(inputUri, DISCORD_MAX_BYTES, videoFormat);
@@ -435,7 +436,7 @@ export async function compressForDiscord(
 export async function compressToTargetSize(
   inputUri: string,
   targetBytes: number,
-  videoFormat: string = 'mp4',
+  videoFormat: VideoFormat = 'mp4',
 ): Promise<CompressResult> {
   if (isVideoFile(inputUri)) {
     return compressVideoToTarget(inputUri, targetBytes, videoFormat);


### PR DESCRIPTION
## 概要

Closes #214

`FfmpegCompressor.ts` の `compressForDiscord` / `compressToTargetSize` / `compressVideoToTarget` で `videoFormat: string` になっていたパラメータを、`store.ts` で定義済みの `VideoFormat` 型（`'mp4' | 'mov' | 'mkv' | 'webm'`）に変更する。

## 変更内容

- `VideoFormat` を `../../state/store` からインポート
- `compressVideoToTarget` の `outputFormat: string` → `outputFormat: VideoFormat`
- `compressForDiscord` の `videoFormat: string` → `videoFormat: VideoFormat`
- `compressToTargetSize` の `videoFormat: string` → `videoFormat: VideoFormat`

## 効果

不正なフォーマット文字列がコンパイル時に検出されるようになり、型安全性が向上する。