### PR TITLE
refactor: expo-file-system/legacy 依存を expo-file-system v2 新API へ移行

### DIFF
--- a/app/src/__tests__/ConversionHistoryModal.test.tsx
+++ b/app/src/__tests__/ConversionHistoryModal.test.tsx
@@ -15,16 +15,25 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   removeItem: jest.fn(),
 }));
 
-jest.mock('expo-file-system/legacy', () => ({
-  getInfoAsync: jest.fn().mockResolvedValue({exists: true, isDirectory: false}),
-  deleteAsync: jest.fn().mockResolvedValue(undefined),
-  copyAsync: jest.fn().mockResolvedValue(undefined),
-  readAsStringAsync: jest.fn().mockResolvedValue(''),
-  writeAsStringAsync: jest.fn().mockResolvedValue(undefined),
-  makeDirectoryAsync: jest.fn().mockResolvedValue(undefined),
-  documentDirectory: 'file:///document/',
-  cacheDirectory: 'file:///cache/',
-}));
+jest.mock('expo-file-system', () => {
+  class MockFile {
+    exists: boolean = true;
+    size: number = 1024;
+    uri: string;
+    constructor(uri: string) { this.uri = uri; this.exists = true; }
+    delete() {}
+    move(dest: any) {}
+  }
+  return {
+    Paths: { cache: { uri: 'file:///cache/' }, join: (...args: string[]) => args.join('/') },
+    File: MockFile,
+    Directory: class {
+      exists = true;
+      constructor() {}
+      list() { return []; }
+    },
+  };
+});
 
 jest.mock('expo-sharing', () => ({
   isAvailableAsync: jest.fn().mockResolvedValue(true),
@@ -400,18 +409,18 @@ describe('フィルタータブ機能', () => {
 
 describe('共有機能 (Issue #165)', () => {
   const Sharing = require('expo-sharing');
-  const FileSystemMock = require('expo-file-system/legacy');
+  const FileSystemMock = require('expo-file-system');
 
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(Alert, 'alert').mockImplementation(() => {});
     Sharing.isAvailableAsync.mockResolvedValue(true);
     Sharing.shareAsync.mockResolvedValue(undefined);
-    FileSystemMock.getInfoAsync.mockResolvedValue({exists: true, isDirectory: false});
+    FileSystemMock.File = class { exists = true; size = 1024; uri: string; constructor(uri: string) { this.uri = uri; } delete() {} move() {} };
   });
 
   it('ファイルが存在する場合、共有ボタンが有効である', async () => {
-    FileSystemMock.getInfoAsync.mockResolvedValue({exists: true, isDirectory: false});
+    FileSystemMock.File = class { exists = true; size = 1024; uri: string; constructor(uri: string) { this.uri = uri; } delete() {} move() {} };
     const renderer = await createWithData([sampleItem]);
     await ReactTestRenderer.act(async () => {});
 
@@ -425,7 +434,7 @@ describe('共有機能 (Issue #165)', () => {
   });
 
   it('ファイルが存在しない場合、共有ボタンが無効である', async () => {
-    FileSystemMock.getInfoAsync.mockResolvedValue({exists: false, isDirectory: false});
+    FileSystemMock.File = class { exists = false; size = 0; uri: string; constructor(uri: string) { this.uri = uri; } delete() {} move() {} };
     const renderer = await createWithData([sampleItem]);
     await ReactTestRenderer.act(async () => {});
 
@@ -439,7 +448,7 @@ describe('共有機能 (Issue #165)', () => {
   });
 
   it('共有ボタンを押すと Sharing.shareAsync が呼ばれる', async () => {
-    FileSystemMock.getInfoAsync.mockResolvedValue({exists: true, isDirectory: false});
+    FileSystemMock.File = class { exists = true; size = 1024; uri: string; constructor(uri: string) { this.uri = uri; } delete() {} move() {} };
     const renderer = await createWithData([sampleItem]);
     await ReactTestRenderer.act(async () => {});
 

--- a/app/src/__tests__/FfmpegCompressor.test.ts
+++ b/app/src/__tests__/FfmpegCompressor.test.ts
@@ -21,21 +21,32 @@ jest.mock('ffmpeg-kit-react-native', () => ({
   },
 }));
 
-jest.mock('expo-file-system', () => ({
-  Paths: {
-    cache: { uri: 'file:///cache/' },
-  },
-}));
+// Per-URI file info store for the File mock
+const mockFileInfoMap = new Map<string, { exists: boolean; size: number }>();
 
-const mockGetInfoAsync = jest.fn();
-const mockReadDirectoryAsync = jest.fn().mockResolvedValue([]);
-const mockDeleteAsync = jest.fn().mockResolvedValue(undefined);
+jest.mock('expo-file-system', () => {
+  class MockFile {
+    _uri: string;
+    constructor(uri: string) { this._uri = uri; }
+    get exists() { return mockFileInfoMap.get(this._uri)?.exists ?? true; }
+    get size() { return mockFileInfoMap.get(this._uri)?.size ?? 0; }
+    delete() {}
+    move(_dest: unknown) {}
+  }
+  class MockDirectory {
+    _uri: string;
+    constructor(uri: string) { this._uri = uri; }
+    get exists() { return mockFileInfoMap.get(this._uri)?.exists ?? true; }
+    list() { return []; }
+  }
+  return {
+    Paths: { cache: { uri: 'file:///cache/' } },
+    File: MockFile,
+    Directory: MockDirectory,
+  };
+});
 
-jest.mock('expo-file-system/legacy', () => ({
-  getInfoAsync: (...args: unknown[]) => mockGetInfoAsync(...args),
-  readDirectoryAsync: (...args: unknown[]) => mockReadDirectoryAsync(...args),
-  deleteAsync: (...args: unknown[]) => mockDeleteAsync(...args),
-}));
+const mockGetFileSizeBytes = jest.fn().mockReturnValue(0);
 
 jest.mock('../data/ffmpeg/ffmpegUtils', () => ({
   generateUniqueFileSuffix: jest.fn().mockReturnValue('12345_abc'),
@@ -45,7 +56,7 @@ jest.mock('../data/ffmpeg/ffmpegUtils', () => ({
     uri: `file:///cache/${stem}_${suffix}`,
     path: `/cache/${stem}_${suffix}`,
   })),
-  getFileSizeBytes: jest.fn().mockImplementation((info: { size?: number }) => info?.size ?? 0),
+  getFileSizeBytes: (...args: unknown[]) => mockGetFileSizeBytes(...args),
   buildFfmpegCommand: jest.fn().mockImplementation((parts: Array<string | number | null | undefined>) =>
     parts.filter((p) => p != null).join(' ')
   ),
@@ -71,7 +82,6 @@ function setupSuccessSession() {
     uri: `file:///cache/${stem}_${suffix}`,
     path: `/cache/${stem}_${suffix}`,
   }));
-  ffmpegUtils.getFileSizeBytes.mockImplementation((info: { size?: number }) => info?.size ?? 0);
   ffmpegUtils.buildFfmpegCommand.mockImplementation((parts: Array<string | number | null | undefined>) =>
     parts.filter((p) => p != null).join(' ')
   );
@@ -85,43 +95,40 @@ function setupSuccessSession() {
 }
 
 /**
- * Image compressor call order:
- *   1. getInfoAsync(inputUri)   — input check
- *   2. getInfoAsync(cacheDir)   — cleanupCachedTempFiles
- *   3+. getInfoAsync(outputUri) — binary search iterations
+ * Image compressor: set up File mock and getFileSizeBytes mock.
+ * - inputUri: exists=true, getFileSizeBytes returns inputSize
+ * - outputUri: exists=true, getFileSizeBytes returns outputSize on each call
  */
 function setupImageFileInfo({
   inputSize = 20 * 1024 * 1024,
   outputSize = 5 * 1024 * 1024, // small enough to be ≤ targetBytes during binary search
 }: { inputSize?: number; outputSize?: number } = {}) {
-  mockGetInfoAsync
-    .mockResolvedValueOnce({ exists: true, size: inputSize }) // 1. input
-    .mockResolvedValueOnce({ exists: true })                  // 2. cache dir
-    .mockResolvedValue({ exists: true, size: outputSize });   // 3+. output (all iterations)
+  mockFileInfoMap.clear();
+  // getFileSizeBytes: first call = inputSize (inputUri), subsequent = outputSize (outputUri)
+  mockGetFileSizeBytes
+    .mockReturnValueOnce(inputSize)
+    .mockReturnValue(outputSize);
 }
 
 /**
- * Video compressor call order (2パス導入後):
- *   1. getInfoAsync(inputUri)   — input check
- *   2. getInfoAsync(cacheDir)   — cleanupCachedTempFiles
- *   3. getInfoAsync(outputUri)  — CRF試行後のサイズ確認
- *   4. getInfoAsync(outputUri)  — 2パス完了後のサイズ確認
+ * Video compressor: set up File mock and getFileSizeBytes mock.
  */
 function setupVideoFileInfo({
   inputSize = 20 * 1024 * 1024,
   outputSize = 5 * 1024 * 1024,
   durationSec = 30,
 }: { inputSize?: number; outputSize?: number; durationSec?: number } = {}) {
+  mockFileInfoMap.clear();
   mockProbeExecute.mockResolvedValue({
     getMediaInformation: jest.fn().mockResolvedValue({
       getDuration: jest.fn().mockReturnValue(String(durationSec)),
     }),
   });
-  mockGetInfoAsync
-    .mockResolvedValueOnce({ exists: true, size: inputSize }) // 1. input
-    .mockResolvedValueOnce({ exists: true })                  // 2. cache dir
-    .mockResolvedValueOnce({ exists: true, size: outputSize * 2 }) // 3. CRF output (target超過で2パスへ)
-    .mockResolvedValueOnce({ exists: true, size: outputSize });     // 4. 2パス後 output
+  // getFileSizeBytes: input, CRF output (target超過), 2パス後 output
+  mockGetFileSizeBytes
+    .mockReturnValueOnce(inputSize)
+    .mockReturnValueOnce(outputSize * 3) // CRF output: 3x outputSize to ensure > DISCORD_MAX_BYTES
+    .mockReturnValue(outputSize);
 }
 
 // ---------------------------------------------------------------------------
@@ -131,16 +138,14 @@ function setupVideoFileInfo({
 describe('compressForDiscord (image)', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    mockReadDirectoryAsync.mockResolvedValue([]);
-    mockDeleteAsync.mockResolvedValue(undefined);
+    mockFileInfoMap.clear();
+    mockGetFileSizeBytes.mockReturnValue(0);
     setupSuccessSession();
   });
 
   it('returns original URI when already below 10 MB', async () => {
     const smallSize = 1 * 1024 * 1024;
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: smallSize }) // 1. input
-      .mockResolvedValueOnce({ exists: true });                  // 2. cache dir
+    mockGetFileSizeBytes.mockReturnValue(smallSize);
     const result = await compressForDiscord('file:///photos/img.jpg');
     expect(result.outputUri).toBe('file:///photos/img.jpg');
     expect(result.compressionRatio).toBe(1);
@@ -161,12 +166,13 @@ describe('compressForDiscord (image)', () => {
   });
 
   it('throws when input does not exist', async () => {
-    mockGetInfoAsync.mockResolvedValueOnce({ exists: false }); // 1. input
+    mockFileInfoMap.set('file:///photos/img.jpg', { exists: false, size: 0 });
     await expect(compressForDiscord('file:///photos/img.jpg')).rejects.toThrow('入力ファイルが存在しません');
   });
 
   it('throws when input file is empty', async () => {
-    mockGetInfoAsync.mockResolvedValueOnce({ exists: true, size: 0 }); // 1. input
+    // exists=true (default from mock), getFileSizeBytes returns 0
+    mockGetFileSizeBytes.mockReturnValue(0);
     await expect(compressForDiscord('file:///photos/img.jpg')).rejects.toThrow('入力ファイルが空（0バイト）です');
   });
 
@@ -190,17 +196,15 @@ describe('compressForDiscord (image)', () => {
 describe('compressForDiscord (video)', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    mockFileInfoMap.clear();
+    mockGetFileSizeBytes.mockReturnValue(0);
     resetH264CodecCache();
-    mockReadDirectoryAsync.mockResolvedValue([]);
-    mockDeleteAsync.mockResolvedValue(undefined);
     setupSuccessSession();
   });
 
   it('returns original URI when video already below 10 MB', async () => {
     const smallSize = 5 * 1024 * 1024;
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: smallSize }) // 1. input
-      .mockResolvedValueOnce({ exists: true });                  // 2. cache dir
+    mockGetFileSizeBytes.mockReturnValue(smallSize);
     const result = await compressForDiscord('file:///videos/clip.mp4');
     expect(result.outputUri).toBe('file:///videos/clip.mp4');
     expect(result.compressionRatio).toBe(1);
@@ -250,15 +254,14 @@ describe('compressForDiscord (video)', () => {
       }),
     });
 
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 50 * 1024 * 1024 })
-      .mockResolvedValueOnce({ exists: true })
-      .mockResolvedValueOnce({ exists: true, size: 20 * 1024 * 1024 })
-      .mockResolvedValueOnce({ exists: true, size: 18 * 1024 * 1024 })
-      .mockResolvedValueOnce({ exists: true, size: 17 * 1024 * 1024 })
-      .mockResolvedValueOnce({ exists: true, size: 16 * 1024 * 1024 })
-      .mockResolvedValueOnce({ exists: true, size: 15 * 1024 * 1024 })
-      .mockResolvedValueOnce({ exists: true, size: 8 * 1024 * 1024 });
+    mockGetFileSizeBytes
+      .mockReturnValueOnce(50 * 1024 * 1024) // input
+      .mockReturnValueOnce(20 * 1024 * 1024) // CRF output
+      .mockReturnValueOnce(18 * 1024 * 1024) // 2pass output
+      .mockReturnValueOnce(17 * 1024 * 1024)
+      .mockReturnValueOnce(16 * 1024 * 1024)
+      .mockReturnValueOnce(15 * 1024 * 1024)
+      .mockReturnValueOnce(8 * 1024 * 1024);
 
     const result = await compressToTargetSize('file:///videos/clip.mp4', target);
 
@@ -275,11 +278,11 @@ describe('compressForDiscord (video)', () => {
       }),
     });
 
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 50 * 1024 * 1024 })  // 1. input
-      .mockResolvedValueOnce({ exists: true, size: 20 * 1024 * 1024 }) // 2. CRF出力（目標超過→2パスへ）
-      .mockResolvedValueOnce({ exists: true, size: 18 * 1024 * 1024 }) // 3. 2パス後出力（目標超過→リトライ）
-      .mockResolvedValueOnce({ exists: true, size: 9 * 1024 * 1024 });  // 4. リトライ後出力（目標以下）
+    mockGetFileSizeBytes
+      .mockReturnValueOnce(50 * 1024 * 1024)  // input
+      .mockReturnValueOnce(20 * 1024 * 1024)  // CRF出力（目標超過→2パスへ）
+      .mockReturnValueOnce(18 * 1024 * 1024)  // 2パス後出力（目標超過→リトライ）
+      .mockReturnValueOnce(9 * 1024 * 1024);  // リトライ後出力（目標以下）
 
     await compressToTargetSize('file:///videos/clip.mp4', target);
 
@@ -288,7 +291,7 @@ describe('compressForDiscord (video)', () => {
   });
 
   it('throws when input does not exist', async () => {
-    mockGetInfoAsync.mockResolvedValueOnce({ exists: false }); // 1. input
+    mockFileInfoMap.set('file:///videos/clip.mp4', { exists: false, size: 0 });
     await expect(compressForDiscord('file:///videos/clip.mp4')).rejects.toThrow('入力ファイルが存在しません');
   });
 });
@@ -300,9 +303,9 @@ describe('compressForDiscord (video)', () => {
 describe('compressToTargetSize', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    mockFileInfoMap.clear();
+    mockGetFileSizeBytes.mockReturnValue(0);
     resetH264CodecCache();
-    mockReadDirectoryAsync.mockResolvedValue([]);
-    mockDeleteAsync.mockResolvedValue(undefined);
     setupSuccessSession();
   });
 
@@ -321,25 +324,22 @@ describe('compressToTargetSize', () => {
   it('returns original when image is already below target', async () => {
     const size = 1 * 1024 * 1024;
     const target = 5 * 1024 * 1024;
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size }) // 1. input
-      .mockResolvedValueOnce({ exists: true });        // 2. cache dir
+    mockGetFileSizeBytes.mockReturnValue(size);
     const result = await compressToTargetSize('file:///photos/img.jpg', target);
     expect(result.compressionRatio).toBe(1);
   });
 
   it('throws when input file does not exist', async () => {
-    mockGetInfoAsync.mockResolvedValueOnce({ exists: false }); // 1. input
+    mockFileInfoMap.set('file:///photos/img.jpg', { exists: false, size: 0 });
     await expect(compressToTargetSize('file:///photos/img.jpg', 5 * 1024 * 1024)).rejects.toThrow('入力ファイルが存在しません');
   });
 
   it('falls back to scale-down when quality-only compression is insufficient', async () => {
     const hugeOutput = 15 * 1024 * 1024;
     const target = 5 * 1024 * 1024;
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 20 * 1024 * 1024 })
-      .mockResolvedValueOnce({ exists: true })
-      .mockResolvedValue({ exists: true, size: hugeOutput });
+    mockGetFileSizeBytes
+      .mockReturnValueOnce(20 * 1024 * 1024) // input
+      .mockReturnValue(hugeOutput);           // all output iterations
 
     await expect(compressToTargetSize('file:///photos/img.jpg', target)).rejects.toThrow('圧縮できませんでした');
     const lastCmd = capturedCmd();

--- a/app/src/__tests__/FfmpegConverter.test.ts
+++ b/app/src/__tests__/FfmpegConverter.test.ts
@@ -14,24 +14,35 @@ jest.mock('ffmpeg-kit-react-native', () => ({
   },
 }));
 
-const mockGetInfoAsync = jest.fn();
-const mockDeleteAsync = jest.fn().mockResolvedValue(undefined);
+// Per-URI file info store for the File mock
+const mockFileInfoMap = new Map<string, { exists: boolean; size: number }>();
+const mockFileDelete = jest.fn();
 
-jest.mock('expo-file-system/legacy', () => ({
-  getInfoAsync: (...args: unknown[]) => mockGetInfoAsync(...args),
-  deleteAsync: (...args: unknown[]) => mockDeleteAsync(...args),
-}));
+jest.mock('expo-file-system', () => {
+  class MockFile {
+    _uri: string;
+    constructor(uri: string) { this._uri = uri; }
+    get exists() { return mockFileInfoMap.get(this._uri)?.exists ?? true; }
+    get size() { return mockFileInfoMap.get(this._uri)?.size ?? 0; }
+    delete() { mockFileDelete(this._uri); }
+    move(_dest: unknown) {}
+  }
+  return { File: MockFile };
+});
+
+const mockGetFileSizeBytes = jest.fn().mockReturnValue(0);
 
 jest.mock('../data/ffmpeg/ffmpegUtils', () => ({
   buildFfmpegCommand: jest.fn().mockImplementation((args: string[]) => args.filter(Boolean).join(' ')),
   generateUniqueFileSuffix: jest.fn().mockReturnValue('12345_abc'),
   extractErrorFromLogs: jest.fn().mockResolvedValue('mock logs'),
   getCacheDir: jest.fn().mockReturnValue('file:///cache/'),
-  getFileSizeBytes: jest.fn().mockImplementation((info: { size?: number }) => info?.size ?? 0),
+  getFileSizeBytes: (...args: unknown[]) => mockGetFileSizeBytes(...args),
 }));
 
 function setupSuccessSession() {
   const { ReturnCode } = jest.requireMock('ffmpeg-kit-react-native');
+  const ffmpegUtils = jest.requireMock('../data/ffmpeg/ffmpegUtils');
   ReturnCode.isSuccess.mockReturnValue(true);
   mockGetReturnCode.mockResolvedValue({});
   mockExecute.mockResolvedValue({
@@ -39,24 +50,27 @@ function setupSuccessSession() {
     getAllLogsAsString: mockGetAllLogsAsString,
     getOutput: mockGetOutput,
   });
+  ffmpegUtils.buildFfmpegCommand.mockImplementation((args: string[]) => args.filter(Boolean).join(' '));
+  ffmpegUtils.generateUniqueFileSuffix.mockReturnValue('12345_abc');
+  ffmpegUtils.extractErrorFromLogs.mockResolvedValue('mock logs');
+  ffmpegUtils.getCacheDir.mockReturnValue('file:///cache/');
 }
 
 describe('convertImage', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    mockFileInfoMap.clear();
+    mockGetFileSizeBytes.mockReturnValue(500);
     const ffmpegUtils = jest.requireMock('../data/ffmpeg/ffmpegUtils');
     ffmpegUtils.buildFfmpegCommand.mockImplementation((args: string[]) => args.filter(Boolean).join(' '));
     ffmpegUtils.generateUniqueFileSuffix.mockReturnValue('12345_abc');
     ffmpegUtils.extractErrorFromLogs.mockResolvedValue('mock logs');
     ffmpegUtils.getCacheDir.mockReturnValue('file:///cache/');
-    ffmpegUtils.getFileSizeBytes.mockImplementation((info: { size?: number }) => info?.size ?? 0);
     setupSuccessSession();
   });
 
   it('JPEG変換時に -q:v を使う', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1000 })
-      .mockResolvedValueOnce({ exists: true, size: 500 });
+    mockGetFileSizeBytes.mockReturnValueOnce(1000).mockReturnValue(500);
 
     const result = await convertImage('file:///photos/in.png', { outputFormat: 'jpeg', quality: 99 });
 
@@ -65,9 +79,7 @@ describe('convertImage', () => {
   });
 
   it('PNG変換時に -compression_level 6 を使う', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1000 })
-      .mockResolvedValueOnce({ exists: true, size: 900 });
+    mockGetFileSizeBytes.mockReturnValueOnce(1000).mockReturnValue(900);
 
     await convertImage('file:///photos/in.jpg', { outputFormat: 'png' });
 
@@ -80,9 +92,7 @@ describe('convertImage', () => {
     { format: 'webp', expectedExt: '.webp', qualityArg: '-quality' },
     { format: 'bmp', expectedExt: '.bmp', qualityArg: '' },
   ])('主要フォーマット変換を網羅できる: $format', async ({ format, expectedExt, qualityArg }) => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1000 })
-      .mockResolvedValueOnce({ exists: true, size: 600 });
+    mockGetFileSizeBytes.mockReturnValueOnce(1000).mockReturnValue(600);
 
     const result = await convertImage('file:///photos/input.png', { outputFormat: format as 'jpeg' | 'png' | 'webp' | 'bmp' });
     const cmd = mockExecute.mock.calls[0][0] as string;
@@ -94,9 +104,7 @@ describe('convertImage', () => {
   });
 
   it('GIF変換時に2パス実行しパレットを削除する', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1000 })
-      .mockResolvedValueOnce({ exists: true, size: 700 });
+    mockGetFileSizeBytes.mockReturnValueOnce(1000).mockReturnValue(700);
 
     const result = await convertImage('file:///photos/in.mp4', { outputFormat: 'gif' });
 
@@ -104,14 +112,13 @@ describe('convertImage', () => {
     expect(mockExecute.mock.calls[0][0]).toContain('fps=10');
     expect(mockExecute.mock.calls[0][0]).toContain('palettegen');
     expect(mockExecute.mock.calls[1][0]).toContain('paletteuse');
-    expect(mockDeleteAsync).toHaveBeenCalledWith('file:///cache/in_converted_12345_abc.gif.palette.png', { idempotent: true });
+    // palette file deletion: new File(`file:///cache/in_converted_12345_abc.gif.palette.png`).delete()
+    expect(mockFileDelete).toHaveBeenCalledWith('file:///cache/in_converted_12345_abc.gif.palette.png');
     expect(result.outputUri).toMatch(/\.gif$/);
   });
 
   it('GIF変換時にfpsとscaleオプションを反映する', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1000 })
-      .mockResolvedValueOnce({ exists: true, size: 650 });
+    mockGetFileSizeBytes.mockReturnValueOnce(1000).mockReturnValue(650);
 
     await convertImage('file:///photos/in.mp4', { outputFormat: 'gif', gifFps: 15, gifScale: 50 });
 
@@ -122,22 +129,22 @@ describe('convertImage', () => {
   });
 
   it('入力ファイルが存在しない場合はエラー', async () => {
-    mockGetInfoAsync.mockResolvedValueOnce({ exists: false });
+    mockFileInfoMap.set('file:///photos/in.jpg', { exists: false, size: 0 });
     await expect(convertImage('file:///photos/in.jpg', { outputFormat: 'webp' })).rejects.toThrow('入力ファイルが存在しません');
   });
 
   it('入力ファイルが0バイトの場合はエラー', async () => {
-    mockGetInfoAsync.mockResolvedValueOnce({ exists: true, size: 0 });
+    mockGetFileSizeBytes.mockReturnValue(0);
     await expect(convertImage('file:///photos/in.jpg', { outputFormat: 'webp' })).rejects.toThrow('入力ファイルが空（0バイト）です');
   });
 
   it('FFmpeg失敗時に出力を削除してエラー', async () => {
     const { ReturnCode } = jest.requireMock('ffmpeg-kit-react-native');
     ReturnCode.isSuccess.mockReturnValue(false);
-    mockGetInfoAsync.mockResolvedValueOnce({ exists: true, size: 1000 });
+    mockGetFileSizeBytes.mockReturnValueOnce(1000).mockReturnValue(0);
 
     await expect(convertImage('file:///photos/in.jpg', { outputFormat: 'webp' })).rejects.toThrow('FFmpegフォーマット変換に失敗しました');
-    expect(mockDeleteAsync).toHaveBeenCalledWith('file:///cache/in_converted_12345_abc.webp', { idempotent: true });
+    expect(mockFileDelete).toHaveBeenCalledWith('file:///cache/in_converted_12345_abc.webp');
   });
 
   it.each([
@@ -146,9 +153,7 @@ describe('convertImage', () => {
     { outputFormat: 'webp' as const, expectedExt: '.webp', expectedArg: '-quality' },
     { outputFormat: 'bmp' as const, expectedExt: '.bmp', expectedArg: '-frames:v 1' },
   ])('主要フォーマット変換($outputFormat)で拡張子とコマンドが一致する', async ({ outputFormat, expectedExt, expectedArg }) => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1200 })
-      .mockResolvedValueOnce({ exists: true, size: 640 });
+    mockGetFileSizeBytes.mockReturnValueOnce(1200).mockReturnValue(640);
 
     const result = await convertImage('file:///photos/input.png', { outputFormat, quality: 50 });
 
@@ -157,9 +162,7 @@ describe('convertImage', () => {
   });
 
   it('GIF変換で出力拡張子と2-pass経路が一致する', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 2000 })
-      .mockResolvedValueOnce({ exists: true, size: 800 });
+    mockGetFileSizeBytes.mockReturnValueOnce(2000).mockReturnValue(800);
 
     const result = await convertImage('file:///photos/anim.webp', { outputFormat: 'gif' });
 
@@ -172,14 +175,13 @@ describe('convertImage', () => {
   it('BMP変換: FFmpeg失敗時に出力を削除してエラーをスローする', async () => {
     const { ReturnCode } = jest.requireMock('ffmpeg-kit-react-native');
     ReturnCode.isSuccess.mockReturnValue(false);
-    mockGetInfoAsync.mockResolvedValueOnce({ exists: true, size: 1000 });
+    mockGetFileSizeBytes.mockReturnValueOnce(1000).mockReturnValue(0);
 
     await expect(
       convertImage('file:///photos/in.jpg', { outputFormat: 'bmp' })
     ).rejects.toThrow('FFmpegフォーマット変換に失敗しました');
-    expect(mockDeleteAsync).toHaveBeenCalledWith(
-      'file:///cache/in_converted_12345_abc.bmp',
-      { idempotent: true }
+    expect(mockFileDelete).toHaveBeenCalledWith(
+      'file:///cache/in_converted_12345_abc.bmp'
     );
   });
 
@@ -187,15 +189,14 @@ describe('convertImage', () => {
     const { ReturnCode } = jest.requireMock('ffmpeg-kit-react-native');
     // pass1 失敗、pass2 は呼ばれない
     ReturnCode.isSuccess.mockReturnValueOnce(false);
-    mockGetInfoAsync.mockResolvedValueOnce({ exists: true, size: 1000 });
+    mockGetFileSizeBytes.mockReturnValueOnce(1000);
 
     await expect(
       convertImage('file:///photos/in.mp4', { outputFormat: 'gif' })
     ).rejects.toThrow('GIF パレット生成に失敗しました');
     // finally ブロックでパレットファイルが削除されること
-    expect(mockDeleteAsync).toHaveBeenCalledWith(
-      'file:///cache/in_converted_12345_abc.gif.palette.png',
-      { idempotent: true }
+    expect(mockFileDelete).toHaveBeenCalledWith(
+      'file:///cache/in_converted_12345_abc.gif.palette.png'
     );
     // pass2 は実行されないこと
     expect(mockExecute).toHaveBeenCalledTimes(1);
@@ -208,17 +209,14 @@ describe('convertImage', () => {
 
     for (const fmt of formats) {
       jest.resetAllMocks();
+      mockFileInfoMap.clear();
       const ffmpegUtils = jest.requireMock('../data/ffmpeg/ffmpegUtils');
       ffmpegUtils.buildFfmpegCommand.mockImplementation((args: string[]) => args.filter(Boolean).join(' '));
       ffmpegUtils.generateUniqueFileSuffix.mockReturnValue('12345_abc');
       ffmpegUtils.extractErrorFromLogs.mockResolvedValue('mock logs');
       ffmpegUtils.getCacheDir.mockReturnValue('file:///cache/');
-      ffmpegUtils.getFileSizeBytes.mockImplementation((info: { size?: number }) => info?.size ?? 0);
+      mockGetFileSizeBytes.mockReturnValueOnce(1000).mockReturnValue(500);
       setupSuccessSession();
-
-      mockGetInfoAsync
-        .mockResolvedValueOnce({ exists: true, size: 1000 })
-        .mockResolvedValueOnce({ exists: true, size: 500 });
 
       const result = await convertImage('file:///photos/input.png', { outputFormat: fmt });
       const ext = result.outputUri.replace(/^.*(\.\w+)$/, '$1');
@@ -229,9 +227,7 @@ describe('convertImage', () => {
   });
 
   it('HEIC入力ファイルから JPEG へ変換できる', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({exists: true, size: 3000})
-      .mockResolvedValueOnce({exists: true, size: 800});
+    mockGetFileSizeBytes.mockReturnValueOnce(3000).mockReturnValue(800);
 
     const result = await convertImage('file:///photos/photo.heic', {
       outputFormat: 'jpeg',
@@ -245,9 +241,7 @@ describe('convertImage', () => {
   });
 
   it('HEIF入力ファイルから PNG へ変換できる', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({exists: true, size: 3500})
-      .mockResolvedValueOnce({exists: true, size: 1200});
+    mockGetFileSizeBytes.mockReturnValueOnce(3500).mockReturnValue(1200);
 
     const result = await convertImage('file:///photos/photo.heif', {
       outputFormat: 'png',

--- a/app/src/__tests__/FfmpegProcessor.test.ts
+++ b/app/src/__tests__/FfmpegProcessor.test.ts
@@ -12,28 +12,39 @@ jest.mock('ffmpeg-kit-react-native', () => ({
   },
 }));
 
-const mockGetInfoAsync = jest.fn();
-const mockDeleteAsync = jest.fn().mockResolvedValue(undefined);
-const mockMoveAsync = jest.fn().mockResolvedValue(undefined);
+// Per-URI file info store for the File mock
+const mockFileInfoMap = new Map<string, { exists: boolean; size: number }>();
 
-jest.mock('expo-file-system/legacy', () => ({
-  getInfoAsync: (...args: unknown[]) => mockGetInfoAsync(...args),
-  deleteAsync: (...args: unknown[]) => mockDeleteAsync(...args),
-  moveAsync: (...args: unknown[]) => mockMoveAsync(...args),
-}));
+jest.mock('expo-file-system', () => {
+  class MockFile {
+    _uri: string;
+    constructor(uri: string) { this._uri = uri; }
+    get exists() { return mockFileInfoMap.get(this._uri)?.exists ?? true; }
+    get size() { return mockFileInfoMap.get(this._uri)?.size ?? 0; }
+    delete() {}
+    move(_dest: unknown) {}
+  }
+  return { File: MockFile };
+});
+
+const mockGetFileSizeBytes = jest.fn().mockReturnValue(0);
 
 jest.mock('../data/ffmpeg/ffmpegUtils', () => ({
   generateUniqueFileSuffix: jest.fn().mockReturnValue('12345_abc'),
   extractErrorFromLogs: jest.fn().mockResolvedValue(''),
   getCacheDir: jest.fn().mockReturnValue('file:///cache/'),
-  getFileSizeBytes: jest.fn().mockImplementation((info: { size?: number }) => info?.size ?? 0),
+  getFileSizeBytes: (...args: unknown[]) => mockGetFileSizeBytes(...args),
 }));
 
 function setupSuccess() {
   const { ReturnCode } = jest.requireMock('ffmpeg-kit-react-native');
+  const ffmpegUtils = jest.requireMock('../data/ffmpeg/ffmpegUtils');
   ReturnCode.isSuccess.mockReturnValue(true);
   mockGetReturnCode.mockResolvedValue({});
   mockExecute.mockResolvedValue({ getReturnCode: mockGetReturnCode });
+  ffmpegUtils.generateUniqueFileSuffix.mockReturnValue('12345_abc');
+  ffmpegUtils.extractErrorFromLogs.mockResolvedValue('');
+  ffmpegUtils.getCacheDir.mockReturnValue('file:///cache/');
 }
 
 function lastCmd() {
@@ -43,27 +54,24 @@ function lastCmd() {
 describe('processWithFfmpeg', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    mockFileInfoMap.clear();
+    mockGetFileSizeBytes.mockReturnValue(1000); // default: files exist with size
     const ffmpegUtils = jest.requireMock('../data/ffmpeg/ffmpegUtils');
     ffmpegUtils.generateUniqueFileSuffix.mockReturnValue('12345_abc');
     ffmpegUtils.extractErrorFromLogs.mockResolvedValue('');
     ffmpegUtils.getCacheDir.mockReturnValue('file:///cache/');
-    ffmpegUtils.getFileSizeBytes.mockImplementation((info: { size?: number }) => info?.size ?? 0);
     setupSuccess();
   });
 
   it('gabigabiLevelマッピングを使う（level=3 -> q:v 24）', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1000 })
-      .mockResolvedValueOnce({ exists: true, size: 800 });
+    mockGetFileSizeBytes.mockReturnValue(1000);
 
     await processWithFfmpeg('file:///in.jpg', 100, 3);
     expect(lastCmd()).toContain('-q:v 24');
   });
 
   it('shrinkExpandEnabledで縮小→再拡大フィルタを追加する', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1000 })
-      .mockResolvedValueOnce({ exists: true, size: 800 });
+    mockGetFileSizeBytes.mockReturnValue(1000);
 
     await processWithFfmpeg('file:///in.jpg', 100, 2, { shrinkExpandEnabled: true, shrinkExpandRate: 40 });
     const cmd = lastCmd();
@@ -78,14 +86,11 @@ describe('processWithFfmpeg', () => {
       .mockReturnValueOnce('p2')
       .mockReturnValueOnce('p3');
 
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 2000 })
-      .mockResolvedValueOnce({ exists: true, size: 700 });
+    mockGetFileSizeBytes.mockReturnValue(700);
 
     await processWithFfmpeg('file:///in.jpg', 100, 2, { multiCompressEnabled: true, multiCompressCount: 3 });
 
     expect(mockExecute).toHaveBeenCalledTimes(3);
-    expect(mockMoveAsync).toHaveBeenCalled();
   });
 
   it.each([
@@ -95,9 +100,7 @@ describe('processWithFfmpeg', () => {
     { input: 'file:///in.bmp', expectedExt: '.bmp' },
     { input: 'file:///in.gif', expectedExt: '.gif' },
   ])('gabigabi経路で出力拡張子が期待通り($input)', async ({ input, expectedExt }) => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1000 })
-      .mockResolvedValueOnce({ exists: true, size: 500 });
+    mockGetFileSizeBytes.mockReturnValue(500);
 
     const result = await processWithFfmpeg(input, 80, 2);
 
@@ -110,18 +113,17 @@ describe('processWithFfmpeg', () => {
 describe('processVideoWithFfmpeg', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    mockFileInfoMap.clear();
+    mockGetFileSizeBytes.mockReturnValue(700);
     const ffmpegUtils = jest.requireMock('../data/ffmpeg/ffmpegUtils');
     ffmpegUtils.generateUniqueFileSuffix.mockReturnValue('12345_abc');
     ffmpegUtils.extractErrorFromLogs.mockResolvedValue('');
     ffmpegUtils.getCacheDir.mockReturnValue('file:///cache/');
-    ffmpegUtils.getFileSizeBytes.mockImplementation((info: { size?: number }) => info?.size ?? 0);
     setupSuccess();
   });
 
   it('mp4でlibx264/aacとcrfを使う', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1000 })
-      .mockResolvedValueOnce({ exists: true, size: 700 });
+    mockGetFileSizeBytes.mockReturnValue(700);
 
     await processVideoWithFfmpeg('file:///in.mp4', 50, 2, 'mp4');
     const cmd = lastCmd();
@@ -131,9 +133,7 @@ describe('processVideoWithFfmpeg', () => {
   });
 
   it('webmでvp9とb:v 0を使う', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1000 })
-      .mockResolvedValueOnce({ exists: true, size: 700 });
+    mockGetFileSizeBytes.mockReturnValue(700);
 
     await processVideoWithFfmpeg('file:///in.webm', 100, 2, 'webm');
     const cmd = lastCmd();
@@ -143,18 +143,14 @@ describe('processVideoWithFfmpeg', () => {
   });
 
   it('compressionRate指定時はmp4のCRFを線形マッピングする', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1000 })
-      .mockResolvedValueOnce({ exists: true, size: 700 });
+    mockGetFileSizeBytes.mockReturnValue(700);
 
     await processVideoWithFfmpeg('file:///in.mp4', 100, 0, 'mp4', 99);
     expect(lastCmd()).toContain('-crf 51');
   });
 
   it('compressionRate指定時はwebmのCRFを線形マッピングする', async () => {
-    mockGetInfoAsync
-      .mockResolvedValueOnce({ exists: true, size: 1000 })
-      .mockResolvedValueOnce({ exists: true, size: 700 });
+    mockGetFileSizeBytes.mockReturnValue(700);
 
     await processVideoWithFfmpeg('file:///in.webm', 100, 0, 'webm', 0);
     expect(lastCmd()).toContain('-crf 33');

--- a/app/src/__tests__/MainScreen.test.tsx
+++ b/app/src/__tests__/MainScreen.test.tsx
@@ -25,17 +25,25 @@ jest.mock('expo-sharing', () => ({
   shareAsync: jest.fn().mockResolvedValue(undefined),
 }));
 
-jest.mock('expo-file-system/legacy', () => ({
-  getInfoAsync: jest.fn().mockResolvedValue({ exists: false, size: 0 }),
-  readDirectoryAsync: jest.fn(),
-  deleteAsync: jest.fn(),
-  cacheDirectory: 'file:///cache/',
-}));
-
-jest.mock('expo-file-system', () => ({
-  Paths: { cache: { uri: 'file:///cache/' } },
-  getInfoAsync: jest.fn().mockResolvedValue({ exists: false, size: 0 }),
-}));
+jest.mock('expo-file-system', () => {
+  class MockFile {
+    exists: boolean = false;
+    size: number = 0;
+    uri: string;
+    constructor(uri: string) { this.uri = uri; }
+    delete() {}
+    move(dest: any) {}
+  }
+  return {
+    Paths: { cache: { uri: 'file:///cache/' }, join: (...args: string[]) => args.join('/') },
+    File: MockFile,
+    Directory: class {
+      exists = true;
+      constructor() {}
+      list() { return []; }
+    },
+  };
+});
 
 jest.mock('expo-media-library', () => ({
   requestPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),

--- a/app/src/__tests__/ffmpegUtils.test.ts
+++ b/app/src/__tests__/ffmpegUtils.test.ts
@@ -15,20 +15,29 @@ jest.mock('ffmpeg-kit-react-native', () => ({
 }));
 
 // Mock expo-file-system
-jest.mock('expo-file-system', () => ({
-  Paths: {
-    get cache() {
-      return { uri: 'file:///cache/' };
+jest.mock('expo-file-system', () => {
+  class MockFile {
+    exists: boolean;
+    size: number;
+    constructor(uri: string) { this.exists = true; this.size = 1024; }
+    delete() {}
+    move(dest: any) {}
+  }
+  class MockDirectory {
+    exists: boolean;
+    constructor(uri: string) { this.exists = true; }
+    list() { return []; }
+  }
+  return {
+    Paths: {
+      get cache() {
+        return { uri: 'file:///cache/' };
+      },
     },
-  },
-}));
-
-// Mock expo-file-system/legacy
-jest.mock('expo-file-system/legacy', () => ({
-  getInfoAsync: jest.fn(),
-  readDirectoryAsync: jest.fn(),
-  deleteAsync: jest.fn(),
-}));
+    File: MockFile,
+    Directory: MockDirectory,
+  };
+});
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn().mockResolvedValue(null),
@@ -133,65 +142,129 @@ describe('getCacheDir', () => {
 });
 
 describe('cleanupCachedTempFiles', () => {
-  let getInfoAsync: jest.Mock;
-  let readDirectoryAsync: jest.Mock;
-  let deleteAsync: jest.Mock;
+  let mockDirectoryExists: boolean;
+  let mockFileList: string[];
+  let mockFileDelete: jest.Mock;
 
   beforeEach(() => {
-    const FileSystem = require('expo-file-system/legacy');
-    getInfoAsync = FileSystem.getInfoAsync as jest.Mock;
-    readDirectoryAsync = FileSystem.readDirectoryAsync as jest.Mock;
-    deleteAsync = FileSystem.deleteAsync as jest.Mock;
+    mockDirectoryExists = true;
+    mockFileList = [];
+    mockFileDelete = jest.fn();
+    const fs = require('expo-file-system');
+    fs.Directory.mockImplementation = undefined;
+    // Override MockDirectory and MockFile for each test
+    fs.Directory = class {
+      exists: boolean;
+      constructor() { this.exists = mockDirectoryExists; }
+      list() { return mockFileList.map(name => ({ name })); }
+    };
+    fs.File = class {
+      exists: boolean;
+      size: number;
+      constructor() { this.exists = true; this.size = 1024; }
+      delete() { mockFileDelete(); }
+      move() {}
+    };
     jest.clearAllMocks();
+    mockFileDelete = jest.fn();
   });
 
   it('キャッシュディレクトリが存在しない場合は何もしない', async () => {
-    getInfoAsync.mockResolvedValue({ exists: false });
+    const fs = require('expo-file-system');
+    mockDirectoryExists = false;
+    fs.Directory = class {
+      exists = false;
+      list() { return []; }
+    };
+    const listSpy = jest.spyOn(fs.Directory.prototype, 'list');
     await cleanupCachedTempFiles();
-    expect(readDirectoryAsync).not.toHaveBeenCalled();
-    expect(deleteAsync).not.toHaveBeenCalled();
+    expect(listSpy).not.toHaveBeenCalled();
   });
 
   it('対象パターンに一致するファイルを削除する', async () => {
-    getInfoAsync.mockResolvedValue({ exists: true });
-    readDirectoryAsync.mockResolvedValue([
-      'video_compressed_123.mp4',
-      'image_gabigabi_456.jpg',
-      'output_converted_789.png',
-      'video_passlog.log',
-    ]);
-    deleteAsync.mockResolvedValue(undefined);
+    const fs = require('expo-file-system');
+    const deletedFiles: string[] = [];
+    fs.Directory = class {
+      exists = true;
+      list() {
+        return [
+          'video_compressed_123.mp4',
+          'image_gabigabi_456.jpg',
+          'output_converted_789.png',
+          'video_passlog.log',
+        ].map(name => ({ name }));
+      }
+    };
+    fs.File = class {
+      uri: string;
+      exists = true;
+      size = 1024;
+      constructor(uri: string) { this.uri = uri; }
+      delete() { deletedFiles.push(this.uri); }
+      move() {}
+    };
     await cleanupCachedTempFiles();
-    expect(deleteAsync).toHaveBeenCalledTimes(4);
+    expect(deletedFiles).toHaveLength(4);
   });
 
   it('対象外のファイルは削除しない', async () => {
-    getInfoAsync.mockResolvedValue({ exists: true });
-    readDirectoryAsync.mockResolvedValue([
-      'photo.jpg',
-      'document.pdf',
-      'video_compressed_123.mp4',
-    ]);
-    deleteAsync.mockResolvedValue(undefined);
+    const fs = require('expo-file-system');
+    const deletedFiles: string[] = [];
+    fs.Directory = class {
+      exists = true;
+      list() {
+        return [
+          'photo.jpg',
+          'document.pdf',
+          'video_compressed_123.mp4',
+        ].map(name => ({ name }));
+      }
+    };
+    fs.File = class {
+      uri: string;
+      exists = true;
+      size = 1024;
+      constructor(uri: string) { this.uri = uri; }
+      delete() { deletedFiles.push(this.uri); }
+      move() {}
+    };
     await cleanupCachedTempFiles();
-    expect(deleteAsync).toHaveBeenCalledTimes(1);
-    expect(deleteAsync).toHaveBeenCalledWith(
-      expect.stringContaining('video_compressed_123.mp4'),
-      { idempotent: true },
-    );
+    expect(deletedFiles).toHaveLength(1);
+    expect(deletedFiles[0]).toContain('video_compressed_123.mp4');
   });
 
-  it('deleteAsyncが失敗してもエラーを投げない', async () => {
-    getInfoAsync.mockResolvedValue({ exists: true });
-    readDirectoryAsync.mockResolvedValue(['video_gabigabi_123.mp4']);
-    deleteAsync.mockRejectedValue(new Error('delete failed'));
+  it('deleteが失敗してもエラーを投げない', async () => {
+    const fs = require('expo-file-system');
+    fs.Directory = class {
+      exists = true;
+      list() { return [{ name: 'video_gabigabi_123.mp4' }]; }
+    };
+    fs.File = class {
+      exists = true;
+      size = 1024;
+      constructor() {}
+      delete() { throw new Error('delete failed'); }
+      move() {}
+    };
     await expect(cleanupCachedTempFiles()).resolves.toBeUndefined();
   });
 
   it('空のキャッシュディレクトリでも正常終了する', async () => {
-    getInfoAsync.mockResolvedValue({ exists: true });
-    readDirectoryAsync.mockResolvedValue([]);
+    const fs = require('expo-file-system');
+    const deletedFiles: string[] = [];
+    fs.Directory = class {
+      exists = true;
+      list() { return []; }
+    };
+    fs.File = class {
+      exists = true;
+      size = 1024;
+      uri: string;
+      constructor(uri: string) { this.uri = uri; }
+      delete() { deletedFiles.push(this.uri); }
+      move() {}
+    };
     await cleanupCachedTempFiles();
-    expect(deleteAsync).not.toHaveBeenCalled();
+    expect(deletedFiles).toHaveLength(0);
   });
 });

--- a/app/src/__tests__/useFileInfo.test.ts
+++ b/app/src/__tests__/useFileInfo.test.ts
@@ -1,14 +1,29 @@
 import {renderHook, act} from '@testing-library/react-native';
 import {Image} from 'react-native';
-import * as FileSystem from 'expo-file-system/legacy';
+import { File } from 'expo-file-system';
 import {FFprobeKit} from 'ffmpeg-kit-react-native';
 import {useFileInfo} from '../hooks/useFileInfo';
 import * as ffmpegUtils from '../data/ffmpeg/ffmpegUtils';
 
 // モック設定
-jest.mock('expo-file-system/legacy', () => ({
-  getInfoAsync: jest.fn(),
-}));
+jest.mock('expo-file-system', () => {
+  class MockFile {
+    exists: boolean = true;
+    size: number = 1024;
+    constructor(uri: string) {}
+    delete() {}
+    move(dest: any) {}
+  }
+  return {
+    Paths: { cache: { uri: 'file:///cache/' }, join: (...args: string[]) => args.join('/') },
+    File: MockFile,
+    Directory: class {
+      exists = true;
+      constructor() {}
+      list() { return []; }
+    },
+  };
+});
 
 jest.mock('ffmpeg-kit-react-native', () => ({
   FFprobeKit: {
@@ -20,7 +35,6 @@ jest.mock('../data/ffmpeg/ffmpegUtils', () => ({
   getFileSizeBytes: jest.fn(),
 }));
 
-const mockedGetInfoAsync = FileSystem.getInfoAsync as jest.Mock;
 const mockedGetFileSizeBytes = ffmpegUtils.getFileSizeBytes as jest.Mock;
 const mockedFFprobeKit = FFprobeKit.execute as jest.Mock;
 
@@ -42,7 +56,6 @@ describe('useFileInfo', () => {
   });
 
   it('画像ファイルのとき Image.getSize が呼ばれ正しい fileInfo が返ること', async () => {
-    mockedGetInfoAsync.mockResolvedValue({exists: true, size: 512 * 1024});
     mockedGetFileSizeBytes.mockReturnValue(512 * 1024);
     getSizeSpy.mockImplementation(
       (_uri: string, success: (w: number, h: number) => void) => {
@@ -72,7 +85,6 @@ describe('useFileInfo', () => {
   });
 
   it('動画ファイルのとき FFprobeKit.execute が呼ばれ width/height が取得されること', async () => {
-    mockedGetInfoAsync.mockResolvedValue({exists: true, size: 2 * 1024 * 1024});
     mockedGetFileSizeBytes.mockReturnValue(2 * 1024 * 1024);
     const mockSession = {
       getOutput: jest.fn().mockResolvedValue(
@@ -104,7 +116,6 @@ describe('useFileInfo', () => {
 
   it('ファイルサイズが 1MB 以上のとき MB 表示になること', async () => {
     const bytes = 1.5 * 1024 * 1024;
-    mockedGetInfoAsync.mockResolvedValue({exists: true, size: bytes});
     mockedGetFileSizeBytes.mockReturnValue(bytes);
     getSizeSpy.mockImplementation(
       (_uri: string, success: (w: number, h: number) => void) => {
@@ -125,7 +136,6 @@ describe('useFileInfo', () => {
 
   it('ファイルサイズが 1MB 未満のとき KB 表示になること', async () => {
     const bytes = 256 * 1024;
-    mockedGetInfoAsync.mockResolvedValue({exists: true, size: bytes});
     mockedGetFileSizeBytes.mockReturnValue(bytes);
     getSizeSpy.mockImplementation(
       (_uri: string, success: (w: number, h: number) => void) => {
@@ -146,7 +156,6 @@ describe('useFileInfo', () => {
 
   it('アンマウント時にキャンセルフラグが立ち state 更新が行われないこと', async () => {
     let resolveGetSize: (w: number, h: number) => void = () => {};
-    mockedGetInfoAsync.mockResolvedValue({exists: true, size: 100 * 1024});
     mockedGetFileSizeBytes.mockReturnValue(100 * 1024);
     getSizeSpy.mockImplementation(
       (_uri: string, success: (w: number, h: number) => void) => {

--- a/app/src/data/ffmpeg/FfmpegCompressor.ts
+++ b/app/src/data/ffmpeg/FfmpegCompressor.ts
@@ -1,5 +1,5 @@
 import { FFmpegKit, FFprobeKit, ReturnCode } from 'ffmpeg-kit-react-native';
-import * as FileSystem from 'expo-file-system/legacy';
+import { File } from 'expo-file-system';
 import { buildFfmpegCommand, generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getPasslogConfig, getFileSizeBytes } from './ffmpegUtils';
 import { VideoFormat } from '../../state/store';
 import { DISCORD_MAX_BYTES } from '../../constants/limits';
@@ -65,11 +65,11 @@ async function compressImageToTarget(
   forceJpeg: boolean = false,
 ): Promise<CompressResult> {
   // 入力ファイルの存在確認とサイズチェック
-  const inputInfo = await FileSystem.getInfoAsync(inputUri, { size: true });
-  if (!inputInfo.exists) {
+  const inputFile = new File(inputUri);
+  if (!inputFile.exists) {
     throw new Error('入力ファイルが存在しません');
   }
-  const originalBytes = getFileSizeBytes(inputInfo);
+  const originalBytes = getFileSizeBytes(inputUri);
   if (originalBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
   }
@@ -116,8 +116,7 @@ async function compressImageToTarget(
       throw new Error('FFmpeg画像圧縮に失敗しました');
     }
 
-    const outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
-  const outBytes = getFileSizeBytes(outInfo);
+    const outBytes = getFileSizeBytes(outputUri);
 
     if (outBytes <= targetBytes) {
       bestQv = mid;
@@ -144,13 +143,12 @@ async function compressImageToTarget(
     if (!ReturnCode.isSuccess(rc)) {
       throw new Error('FFmpeg画像圧縮（スケールダウン）に失敗しました');
     }
-    const outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
-    bestBytes = getFileSizeBytes(outInfo);
+    bestBytes = getFileSizeBytes(outputUri);
   }
 
   // リトライ後も目標サイズを超えている場合はエラーを投げる (#290)
   if (bestBytes > targetBytes) {
-    await FileSystem.deleteAsync(outputUri, { idempotent: true });
+    try { new File(outputUri).delete(); } catch {}
     const targetMB = (targetBytes / (1024 * 1024)).toFixed(1);
     throw new Error(`画像を目標サイズ（${targetMB}MB）以下に圧縮できませんでした。`);
   }
@@ -175,11 +173,11 @@ async function compressVideoToTarget(
   outputFormat: VideoFormat = 'mp4',
 ): Promise<CompressResult> {
   // 入力ファイルの存在確認とサイズチェック
-  const inputInfo = await FileSystem.getInfoAsync(inputUri, { size: true });
-  if (!inputInfo.exists) {
+  const inputFile2 = new File(inputUri);
+  if (!inputFile2.exists) {
     throw new Error('入力ファイルが存在しません');
   }
-  const originalBytes = getFileSizeBytes(inputInfo);
+  const originalBytes = getFileSizeBytes(inputUri);
   if (originalBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
   }
@@ -217,9 +215,8 @@ async function compressVideoToTarget(
   const { uri: passlogUri, path: passlogFilesystemPath } = getPasslogConfig(stem, suffix);
 
   // pass1 開始前に古い passlog ファイルを削除して再試行時の混入を防ぐ (#216)
-  // deleteAsync は file:// URI が必要なため passlogUri を使用する (#276)
-  await FileSystem.deleteAsync(`${passlogUri}-0.log`, { idempotent: true });
-  await FileSystem.deleteAsync(`${passlogUri}-0.log.mbtree`, { idempotent: true });
+  try { new File(`${passlogUri}-0.log`).delete(); } catch {}
+  try { new File(`${passlogUri}-0.log.mbtree`).delete(); } catch {}
 
   // コーデック設定: webm の場合は libvpx-vp9/libopus, それ以外は libx264/aac
   const isWebm = outputFormat.toLowerCase() === 'webm';
@@ -255,8 +252,7 @@ async function compressVideoToTarget(
     const crfSession = await FFmpegKit.execute(crfCmd);
     const crfRc = await crfSession.getReturnCode();
     if (ReturnCode.isSuccess(crfRc)) {
-      const crfInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
-      const crfBytes = getFileSizeBytes(crfInfo);
+      const crfBytes = getFileSizeBytes(outputUri);
       if (crfBytes > 0 && crfBytes <= targetBytes) {
         useTwoPass = false;
       }
@@ -307,17 +303,16 @@ async function compressVideoToTarget(
         throw new Error(`FFmpeg 2パス目に失敗しました: ${logs}`);
       }
     } catch (err) {
-      await FileSystem.deleteAsync(outputUri, { idempotent: true });
+      try { new File(outputUri).delete(); } catch {}
       throw err;
     } finally {
       // 成功・失敗・キャンセルいずれの場合も passlog 一時ファイルを削除する (#234)
-      await FileSystem.deleteAsync(`${passlogUri}-0.log`, { idempotent: true });
-      await FileSystem.deleteAsync(`${passlogUri}-0.log.mbtree`, { idempotent: true });
+      try { new File(`${passlogUri}-0.log`).delete(); } catch {}
+      try { new File(`${passlogUri}-0.log.mbtree`).delete(); } catch {}
     }
   }
 
-  let outInfo = await FileSystem.getInfoAsync(outputUri, { size: true });
-  let outputBytes = getFileSizeBytes(outInfo);
+  let outputBytes = getFileSizeBytes(outputUri);
   let currentOutputUri = outputUri;
 
   // 出力サイズ検証: 目標を超えていたらビットレートを下げてリトライ（最大10回）
@@ -363,39 +358,37 @@ async function compressVideoToTarget(
     const r1 = await FFmpegKit.execute(retry1Cmd);
     if (!ReturnCode.isSuccess(await r1.getReturnCode())) {
       // passlog を確実に削除してから次のリトライへ
-      await FileSystem.deleteAsync(`${retryPasslogUri}-0.log`, { idempotent: true });
-      await FileSystem.deleteAsync(`${retryPasslogUri}-0.log.mbtree`, { idempotent: true });
+      try { new File(`${retryPasslogUri}-0.log`).delete(); } catch {}
+      try { new File(`${retryPasslogUri}-0.log.mbtree`).delete(); } catch {}
       continue;
     }
     const r2 = await FFmpegKit.execute(retry2Cmd);
     // リトライの passlog 一時ファイルを削除（成功・失敗いずれも）(#234)
-    await FileSystem.deleteAsync(`${retryPasslogUri}-0.log`, { idempotent: true });
-    await FileSystem.deleteAsync(`${retryPasslogUri}-0.log.mbtree`, { idempotent: true });
+    try { new File(`${retryPasslogUri}-0.log`).delete(); } catch {}
+    try { new File(`${retryPasslogUri}-0.log.mbtree`).delete(); } catch {}
     if (!ReturnCode.isSuccess(await r2.getReturnCode())) {
-      await FileSystem.deleteAsync(retryOutputUri, { idempotent: true });
+      try { new File(retryOutputUri).delete(); } catch {}
       continue;
     }
 
-    const retryInfo = await FileSystem.getInfoAsync(retryOutputUri, { size: true });
-    const retryBytes = getFileSizeBytes(retryInfo);
+    const retryBytes = getFileSizeBytes(retryOutputUri);
     if (retryBytes > 0) {
       outputBytes = retryBytes;
-      outInfo = retryInfo;
       currentOutputUri = retryOutputUri;
     } else {
       // 0バイトの無効な出力ファイルを削除してキャッシュに残らないようにする
-      await FileSystem.deleteAsync(retryOutputUri, { idempotent: true });
+      try { new File(retryOutputUri).delete(); } catch {}
     }
   }
 
   // リトライ成功により初回出力ファイルが不要になった場合は削除する (#206)
   if (currentOutputUri !== outputUri) {
-    await FileSystem.deleteAsync(outputUri, { idempotent: true });
+    try { new File(outputUri).delete(); } catch {}
   }
 
   // リトライ後も目標サイズを超えている場合はエラーを投げてサイレント超過を防ぐ (#286)
   if (outputBytes > targetBytes) {
-    await FileSystem.deleteAsync(currentOutputUri, { idempotent: true });
+    try { new File(currentOutputUri).delete(); } catch {}
     const targetMB = Math.round(targetBytes / (1024 * 1024));
     throw new Error(`リトライを繰り返しましたが、目標サイズ（${targetMB}MB）以下に圧縮できませんでした。`);
   }

--- a/app/src/data/ffmpeg/FfmpegConverter.ts
+++ b/app/src/data/ffmpeg/FfmpegConverter.ts
@@ -1,5 +1,5 @@
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
-import * as FileSystem from 'expo-file-system/legacy';
+import { File } from 'expo-file-system';
 import { buildFfmpegCommand, generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getFileSizeBytes } from './ffmpegUtils';
 
 export type ImageFormat = 'jpeg' | 'png' | 'webp' | 'bmp' | 'gif';
@@ -36,11 +36,11 @@ export async function convertImage(
   options: ConvertOptions,
 ): Promise<FfmpegConvertResult> {
   // 入力ファイルの存在確認とサイズチェック
-  const inputInfo = await FileSystem.getInfoAsync(inputUri, { size: true });
-  if (!inputInfo.exists) {
+  const inputFile = new File(inputUri);
+  if (!inputFile.exists) {
     throw new Error('入力ファイルが存在しません');
   }
-  const inputBytes = getFileSizeBytes(inputInfo);
+  const inputBytes = getFileSizeBytes(inputUri);
   if (inputBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
   }
@@ -136,7 +136,7 @@ export async function convertImage(
       rc = await session.getReturnCode();
     } finally {
       // パレットファイルをクリーンアップ（結果に関わらず）
-      await FileSystem.deleteAsync(`file://${palettePath}`, { idempotent: true });
+      try { new File(`file://${palettePath}`).delete(); } catch {}
     }
   } else {
     const cmd = buildFfmpegCommand([
@@ -154,16 +154,16 @@ export async function convertImage(
 
   if (!ReturnCode.isSuccess(rc)) {
     const logs = await extractErrorFromLogs(session);
-    await FileSystem.deleteAsync(outputUri, { idempotent: true });
+    try { new File(outputUri).delete(); } catch {}
     throw new Error(`FFmpegフォーマット変換に失敗しました: ${logs}`);
   }
 
-  const info = await FileSystem.getInfoAsync(outputUri, { size: true });
-  if (!info.exists) {
+  const outFile = new File(outputUri);
+  if (!outFile.exists) {
     throw new Error('FFmpeg出力ファイルが見つかりません');
   }
   return {
     outputUri,
-    outputBytes: getFileSizeBytes(info),
+    outputBytes: getFileSizeBytes(outputUri),
   };
 }

--- a/app/src/data/ffmpeg/FfmpegProcessor.ts
+++ b/app/src/data/ffmpeg/FfmpegProcessor.ts
@@ -1,5 +1,5 @@
 import { FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native';
-import * as FileSystem from 'expo-file-system/legacy';
+import { File } from 'expo-file-system';
 import { generateUniqueFileSuffix, extractErrorFromLogs, getCacheDir, getFileSizeBytes } from './ffmpegUtils';
 import { VideoFormat } from '../../state/store';
 
@@ -93,12 +93,12 @@ export async function processVideoWithFfmpeg(
     throw new Error('compressionRate must be 0-99');
   }
 
-  const inputInfo = await FileSystem.getInfoAsync(inputUri, { size: true });
-  if (!inputInfo.exists) {
+  const inputFileV = new File(inputUri);
+  if (!inputFileV.exists) {
     throw new Error('入力ファイルが存在しません');
   }
-  const inputBytes = getFileSizeBytes(inputInfo);
-  if (inputBytes === 0) {
+  const inputBytesV = getFileSizeBytes(inputUri);
+  if (inputBytesV === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
   }
 
@@ -162,17 +162,17 @@ export async function processVideoWithFfmpeg(
       throw new Error(`FFmpeg処理に失敗しました: ${logs}`);
     }
   } catch (err) {
-    await FileSystem.deleteAsync(outputUri, { idempotent: true });
+    try { new File(outputUri).delete(); } catch {}
     throw err;
   }
 
-  const info = await FileSystem.getInfoAsync(outputUri, { size: true });
-  if (!info.exists) {
+  const outFileV = new File(outputUri);
+  if (!outFileV.exists) {
     throw new Error('FFmpeg出力ファイルが見つかりません');
   }
   return {
     outputUri,
-    outputBytes: getFileSizeBytes(info),
+    outputBytes: getFileSizeBytes(outputUri),
   };
 }
 
@@ -204,11 +204,11 @@ export async function processWithFfmpeg(
   } = options;
 
   // 入力ファイルの存在確認とサイズチェック
-  const inputInfo = await FileSystem.getInfoAsync(inputUri, { size: true });
-  if (!inputInfo.exists) {
+  const inputFileP = new File(inputUri);
+  if (!inputFileP.exists) {
     throw new Error('入力ファイルが存在しません');
   }
-  const inputBytes = getFileSizeBytes(inputInfo);
+  const inputBytes = getFileSizeBytes(inputUri);
   if (inputBytes === 0) {
     throw new Error('入力ファイルが空（0バイト）です');
   }
@@ -264,7 +264,7 @@ export async function processWithFfmpeg(
       throw new Error(`FFmpeg処理に失敗しました: ${logs}`);
     }
   } catch (err) {
-    await FileSystem.deleteAsync(outputUri, { idempotent: true });
+    try { new File(outputUri).delete(); } catch {}
     throw err;
   }
 
@@ -304,7 +304,7 @@ export async function processWithFfmpeg(
         // moveAsync 完了前に outputUri を削除すると moveAsync 失敗時にデータが消失する
         // リスクがある（Issue #195, #201）。
         if (currentInput !== outputUri) {
-          await FileSystem.deleteAsync(currentInput, { idempotent: true });
+          try { new File(currentInput).delete(); } catch {}
         }
         currentInput = passUri;
         finalTempUri = passUri;
@@ -314,24 +314,24 @@ export async function processWithFfmpeg(
       // moveAsync の前に outputUri を削除しておくことで上書きを保証する。
       // この時点で currentInput !== outputUri が保証されているため安全に削除できる。
       if (finalTempUri) {
-        await FileSystem.deleteAsync(outputUri, { idempotent: true });
-        await FileSystem.moveAsync({ from: finalTempUri, to: outputUri });
+        try { new File(outputUri).delete(); } catch {}
+        new File(finalTempUri).move(new File(outputUri));
         finalTempUri = null; // move 成功
       }
     } finally {
       // エラー発生時、または move 失敗時に残存した一時ファイルをクリーンアップする
       if (finalTempUri && finalTempUri !== outputUri) {
-        await FileSystem.deleteAsync(finalTempUri, { idempotent: true });
+        try { new File(finalTempUri).delete(); } catch {}
       }
     }
   }
 
-  const info = await FileSystem.getInfoAsync(outputUri, { size: true });
-  if (!info.exists) {
+  const outFileP2 = new File(outputUri);
+  if (!outFileP2.exists) {
     throw new Error('FFmpeg出力ファイルが見つかりません');
   }
   return {
     outputUri,
-    outputBytes: getFileSizeBytes(info),
+    outputBytes: getFileSizeBytes(outputUri),
   };
 }

--- a/app/src/data/ffmpeg/ffmpegUtils.ts
+++ b/app/src/data/ffmpeg/ffmpegUtils.ts
@@ -1,6 +1,5 @@
 import { FFmpegSession } from 'ffmpeg-kit-react-native';
-import { Paths } from 'expo-file-system';
-import * as FileSystem from 'expo-file-system/legacy';
+import { Paths, File, Directory } from 'expo-file-system';
 import {getConversionHistory} from '../history/conversionHistory';
 
 /**
@@ -70,9 +69,9 @@ export function getPasslogConfig(stem: string, suffix: string): { uri: string, p
 export async function cleanupCachedTempFiles(): Promise<void> {
   try {
     const cacheDir = getCacheDir();
-    const dirInfo = await FileSystem.getInfoAsync(cacheDir);
-    if (!dirInfo.exists) return;
-    const result = await FileSystem.readDirectoryAsync(cacheDir);
+    const dirFile = new Directory(cacheDir);
+    if (!dirFile.exists) return;
+    const result = new Directory(cacheDir).list().map(f => f.name);
     const tempPattern = /_(compressed|gabigabi|converted)_|_passlog/;
 
     // 変換履歴のoutputPathに含まれるファイルはスキップ（案C: #155）
@@ -87,7 +86,7 @@ export async function cleanupCachedTempFiles(): Promise<void> {
     await Promise.all(
       result
         .filter(name => tempPattern.test(name) && !historyFileNames.has(name))
-        .map(name => FileSystem.deleteAsync(cacheDir + name, { idempotent: true })),
+        .map(name => { try { new File(cacheDir + name).delete(); } catch {} return Promise.resolve(); }),
     );
   } catch {
     // クリーンアップ失敗は無視して処理を続行する
@@ -95,16 +94,12 @@ export async function cleanupCachedTempFiles(): Promise<void> {
 }
 
 /**
- * expo-file-system の getInfoAsync 結果からファイルサイズを安全に取得する。
- * ファイルが存在しない場合や size プロパティがない場合は 0 を返す。
+ * ファイルURIからファイルサイズを安全に取得する。
+ * ファイルが存在しない場合は 0 を返す。
  */
-function hasNumericSize(info: FileSystem.FileInfo): info is FileSystem.FileInfo & { size: number } {
-  return 'size' in info && typeof info.size === 'number';
-}
-
-export function getFileSizeBytes(info: FileSystem.FileInfo): number {
-  if (!info.exists) return 0;
-  return hasNumericSize(info) ? info.size : 0;
+export function getFileSizeBytes(uri: string): number {
+  const f = new File(uri);
+  return f.exists ? f.size : 0;
 }
 
 

--- a/app/src/hooks/useFileInfo.ts
+++ b/app/src/hooks/useFileInfo.ts
@@ -1,6 +1,6 @@
 import {useEffect, useState} from 'react';
 import {Image} from 'react-native';
-import * as FileSystem from 'expo-file-system/legacy';
+import { File } from 'expo-file-system';
 import {FFprobeKit} from 'ffmpeg-kit-react-native';
 import {getFileSizeBytes} from '../data/ffmpeg/ffmpegUtils';
 
@@ -25,8 +25,8 @@ export const useFileInfo = (
     let cancelled = false;
     (async () => {
       try {
-        const info = await FileSystem.getInfoAsync(selectedImage, {size: true});
-        const bytes = getFileSizeBytes(info);
+        const fileInst = new File(selectedImage);
+        const bytes = getFileSizeBytes(selectedImage);
         const sizeStr =
           bytes >= 1024 * 1024
             ? `${(bytes / (1024 * 1024)).toFixed(2)} MB`

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 import * as MediaLibrary from 'expo-media-library';
 import Share from 'react-native-share';
-import * as FileSystem from 'expo-file-system/legacy';
+import { File } from 'expo-file-system';
 import ErrorModal from '../components/ErrorModal';
 import ImageModal from '../components/ImageModal';
 import {useAppStore} from '../state/store';
@@ -243,8 +243,8 @@ const MainScreen = () => {
       let historyAction: 'gabigabi' | 'convert' = 'gabigabi';
       let inputBytes = 0;
 
-      const inputInfo = await FileSystem.getInfoAsync(selectedImage, {size: true});
-      inputBytes = getFileSizeBytes(inputInfo);
+      const inputInfo = new File(selectedImage);
+      inputBytes = getFileSizeBytes(selectedImage);
       processingNotificationId = await notifyProcessingUpdate(t('notifyInputAnalyzed'), processingNotificationId);
 
       if (selectedMediaType === 'video') {
@@ -380,8 +380,8 @@ const MainScreen = () => {
     setProcessingAction('targetSize');
     let processingNotificationId = await notifyProcessingStarted(t('notifyCompressStarted'));
     try {
-      const inputInfo = await FileSystem.getInfoAsync(selectedImage, {size: true});
-      const inputBytes = getFileSizeBytes(inputInfo);
+      const inputInfo2 = new File(selectedImage);
+      const inputBytes = getFileSizeBytes(selectedImage);
       processingNotificationId = await notifyProcessingUpdate(t('notifyCompressProcessing'), processingNotificationId);
       const result = await compressToTargetSize(selectedImage, targetBytes, videoOutputFormat);
       setProcessedImage(result.outputUri);

--- a/app/src/screens/components/ConversionHistoryModal.tsx
+++ b/app/src/screens/components/ConversionHistoryModal.tsx
@@ -10,7 +10,7 @@ import {
   ActivityIndicator,
   Image,
 } from 'react-native';
-import * as FileSystem from 'expo-file-system/legacy';
+import { File } from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
 import * as VideoThumbnails from 'expo-video-thumbnails';
 import {
@@ -142,9 +142,7 @@ const HistoryItem: React.FC<{item: ConversionHistoryItem; onDelete: (id: string)
 
   useEffect(() => {
     const path = item.outputPath.startsWith('file://') ? item.outputPath : `file://${item.outputPath}`;
-    FileSystem.getInfoAsync(path)
-      .then(info => setFileExists(info.exists))
-      .catch(() => setFileExists(false));
+    setFileExists(new File(path).exists);
   }, [item.outputPath]);
 
   const handleShare = useCallback(async () => {


### PR DESCRIPTION
Closes #215

## 変更内容
- expo-file-system/legacy を expo-file-system v2 新APIへ移行
- File, Directory クラスを使用
- getInfoAsync → new File(uri).exists / .size （同期アクセス）
- deleteAsync → File.delete()
- moveAsync → File.move()
- readDirectoryAsync → Directory.list()
- getFileSizeBytes のシグネチャを string URI 引数に変更
- テストファイルの expo-file-system/legacy モックを File/Directory モックに更新

## 対象ファイル
- src/data/ffmpeg/FfmpegCompressor.ts
- src/data/ffmpeg/FfmpegConverter.ts
- src/data/ffmpeg/FfmpegProcessor.ts
- src/data/ffmpeg/ffmpegUtils.ts
- src/hooks/useFileInfo.ts
- src/screens/MainScreen.tsx
- src/screens/components/ConversionHistoryModal.tsx
- 各テストファイル