### PR TITLE
refactor: deprecated な SafeAreaView を safe-area-context に移行

### DIFF
--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -1,7 +1,6 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 import {
-  SafeAreaView,
   Text,
   View,
   TouchableOpacity,


### PR DESCRIPTION
Closes #219

## 変更内容
- MainScreen の SafeAreaView import 元を react-native-safe-area-context へ変更
- useSafeAreaInsets と同じパッケージへそろえて deprecated warning を解消

## 確認
- npm test -- --runInBand __tests__/App.test.tsx src/__tests__/MainScreen.test.tsx