### PR TITLE
fix: resolve lint-blocking errors

### DIFF
--- a/app/src/__tests__/ConversionHistoryModal.test.tsx
+++ b/app/src/__tests__/ConversionHistoryModal.test.tsx
@@ -57,8 +57,11 @@ jest.mock('../data/history/conversionHistory', () => ({
 // ---- インポート ----
 
 import ConversionHistoryModal from '../screens/components/ConversionHistoryModal';
-import {getConversionHistory, clearConversionHistory} from '../data/history/conversionHistory';
-import {ConversionHistoryItem} from '../data/history/conversionHistory';
+import {
+  getConversionHistory,
+  clearConversionHistory,
+  ConversionHistoryItem,
+} from '../data/history/conversionHistory';
 
 const mockedGetHistory = getConversionHistory as jest.Mock;
 const mockedClearHistory = clearConversionHistory as jest.Mock;

--- a/app/src/screens/MainScreen.tsx
+++ b/app/src/screens/MainScreen.tsx
@@ -16,7 +16,6 @@ import { File } from 'expo-file-system';
 import ErrorModal from '../components/ErrorModal';
 import ImageModal from '../components/ImageModal';
 import {useAppStore} from '../state/store';
-import {ConvertMethod} from '../state/store';
 import {resizeImage} from '../domain/useResizeImage';
 import {compressToTargetSize} from '../domain/useDiscordCompress';
 import {convertImage, formatBytes, ImageFormat} from '../domain/convertImage';

--- a/app/src/screens/components/PreviewCard.tsx
+++ b/app/src/screens/components/PreviewCard.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import {View, Text, TouchableOpacity, Image} from 'react-native';
-import {StyleSheet} from 'react-native';
+import {View, Text, TouchableOpacity, Image, StyleSheet} from 'react-native';
 import {Svg, Path} from 'react-native-svg';
 import {t} from '../../i18n';
-import {CARD_BG, ACCENT, ACCENT2, TEXT_SECONDARY, BORDER} from './sharedStyles';
+import {CARD_BG, ACCENT, TEXT_SECONDARY, BORDER} from './sharedStyles';
 
 export interface PreviewCardProps {
   label: string;

--- a/app/web-server.js
+++ b/app/web-server.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const path = require('path');
-const { createReadStream } = require('fs');
 
 const app = express();
 const PORT = 3000;
@@ -31,6 +30,6 @@ app.get('/', (req, res) => {
 });
 
 app.listen(PORT, () => {
-  console.log(\`🚀 Web server running at http://localhost:\${PORT}\`);
+  console.log(`🚀 Web server running at http://localhost:${PORT}`);
   console.log('📱 convert2gabigabi UI is ready!');
-}); 
+});


### PR DESCRIPTION
## 概要
- MainScreen と PreviewCard の重複 import を解消
- web-server.js の壊れたテンプレートリテラルを修正
- lint で止まっていた ConversionHistoryModal テストの重複 import も整理

## 確認
- `cd app && npm run lint` で error 0 を確認

Closes #224