### PR TITLE
style: reduce lint warnings in app settings files

### DIFF
--- a/app/src/screens/components/SettingsPanel.tsx
+++ b/app/src/screens/components/SettingsPanel.tsx
@@ -1,38 +1,34 @@
 import React from 'react';
-import {View, Text, TouchableOpacity, Switch} from 'react-native';
+import { View, Text, TouchableOpacity, Switch } from 'react-native';
+
+import { sharedStyles, ACCENT, ACCENT2, BORDER } from './sharedStyles';
 import CustomSlider from '../../components/CustomSlider';
 import ResizeSlider from '../../components/ResizeSlider';
-import {VideoFormat} from '../../state/store';
-import {ImageFormat} from '../../domain/convertImage';
-import {t} from '../../i18n';
-import {
-  sharedStyles,
-  ACCENT,
-  ACCENT2,
-  BORDER,
-} from './sharedStyles';
+import { ImageFormat } from '../../domain/convertImage';
+import { t } from '../../i18n';
+import { VideoFormat } from '../../state/store';
 
-const FORMAT_OPTIONS: {label: string; value: ImageFormat}[] = [
-  {label: 'JPEG', value: 'jpeg'},
-  {label: 'PNG', value: 'png'},
-  {label: 'WebP', value: 'webp'},
-  {label: 'BMP', value: 'bmp'},
-  {label: 'GIF', value: 'gif'},
+const FORMAT_OPTIONS: { label: string; value: ImageFormat }[] = [
+  { label: 'JPEG', value: 'jpeg' },
+  { label: 'PNG', value: 'png' },
+  { label: 'WebP', value: 'webp' },
+  { label: 'BMP', value: 'bmp' },
+  { label: 'GIF', value: 'gif' },
 ];
 
-const VIDEO_FORMAT_OPTIONS: {label: string; value: VideoFormat}[] = [
-  {label: 'MP4', value: 'mp4'},
-  {label: 'MOV', value: 'mov'},
-  {label: 'MKV', value: 'mkv'},
-  {label: 'WebM', value: 'webm'},
+const VIDEO_FORMAT_OPTIONS: { label: string; value: VideoFormat }[] = [
+  { label: 'MP4', value: 'mp4' },
+  { label: 'MOV', value: 'mov' },
+  { label: 'MKV', value: 'mkv' },
+  { label: 'WebM', value: 'webm' },
 ];
 
-const GABIGABI_LEVELS: {label: string; value: number}[] = [
-  {label: '1', value: 1},
-  {label: '2', value: 2},
-  {label: '3', value: 3},
-  {label: '4', value: 4},
-  {label: '5', value: 5},
+const GABIGABI_LEVELS: { label: string; value: number }[] = [
+  { label: '1', value: 1 },
+  { label: '2', value: 2 },
+  { label: '3', value: 3 },
+  { label: '4', value: 4 },
+  { label: '5', value: 5 },
 ];
 
 interface SettingsPanelProps {
@@ -95,21 +91,27 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
     <View style={sharedStyles.sectionContainer}>
       <Text style={sharedStyles.sectionTitle}>{t('template')}</Text>
       <View style={sharedStyles.templateBlock}>
-        <Text style={sharedStyles.templateBlockLabel}>{t('gabigabiLevel')}</Text>
+        <Text style={sharedStyles.templateBlockLabel}>
+          {t('gabigabiLevel')}
+        </Text>
         <View style={sharedStyles.formatRow}>
           {GABIGABI_LEVELS.map(item => (
             <TouchableOpacity
               key={item.value}
               style={[
                 sharedStyles.formatButton,
-                gabigabiLevel === item.value && sharedStyles.gabigabiButtonActive,
+                gabigabiLevel === item.value &&
+                  sharedStyles.gabigabiButtonActive,
               ]}
-              onPress={() => onTemplateSelect(item.value)}>
+              onPress={() => onTemplateSelect(item.value)}
+            >
               <Text
                 style={[
                   sharedStyles.formatButtonText,
-                  gabigabiLevel === item.value && sharedStyles.formatButtonTextActive,
-                ]}>
+                  gabigabiLevel === item.value &&
+                    sharedStyles.formatButtonTextActive,
+                ]}
+              >
                 {item.label}
               </Text>
             </TouchableOpacity>
@@ -142,17 +144,25 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 key={opt.value}
                 style={[
                   sharedStyles.formatButton,
-                  videoOutputFormat === opt.value && sharedStyles.formatButtonActive,
+                  videoOutputFormat === opt.value &&
+                    sharedStyles.formatButtonActive,
                 ]}
                 onPress={() => onVideoOutputFormatChange(opt.value)}
                 accessibilityRole="button"
-                accessibilityLabel={`${t('outputFormatAccessibility')} ${opt.label}`}
-                accessibilityState={{selected: videoOutputFormat === opt.value}}>
+                accessibilityLabel={`${t('outputFormatAccessibility')} ${
+                  opt.label
+                }`}
+                accessibilityState={{
+                  selected: videoOutputFormat === opt.value,
+                }}
+              >
                 <Text
                   style={[
                     sharedStyles.formatButtonText,
-                    videoOutputFormat === opt.value && sharedStyles.formatButtonTextActive,
-                  ]}>
+                    videoOutputFormat === opt.value &&
+                      sharedStyles.formatButtonTextActive,
+                  ]}
+                >
                   {opt.label}
                 </Text>
               </TouchableOpacity>
@@ -163,7 +173,9 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
       {selectedMediaType !== 'video' && (
         <>
           {selectedMediaType === null && (
-            <Text style={[sharedStyles.formatGroupLabel, {marginTop: 12}]}>{t('image')}</Text>
+            <Text style={[sharedStyles.formatGroupLabel, { marginTop: 12 }]}>
+              {t('image')}
+            </Text>
           )}
           <View style={sharedStyles.formatRow}>
             {FORMAT_OPTIONS.map(opt => (
@@ -175,13 +187,18 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
                 ]}
                 onPress={() => onOutputFormatChange(opt.value)}
                 accessibilityRole="button"
-                accessibilityLabel={`${t('outputFormatAccessibility')} ${opt.label}`}
-                accessibilityState={{selected: outputFormat === opt.value}}>
+                accessibilityLabel={`${t('outputFormatAccessibility')} ${
+                  opt.label
+                }`}
+                accessibilityState={{ selected: outputFormat === opt.value }}
+              >
                 <Text
                   style={[
                     sharedStyles.formatButtonText,
-                    outputFormat === opt.value && sharedStyles.formatButtonTextActive,
-                  ]}>
+                    outputFormat === opt.value &&
+                      sharedStyles.formatButtonTextActive,
+                  ]}
+                >
                   {opt.label}
                 </Text>
               </TouchableOpacity>
@@ -230,10 +247,14 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
           </View>
         </>
       )}
-      {((selectedMediaType !== 'video' && (outputFormat === 'jpeg' || outputFormat === 'webp')) || selectedMediaType === 'video') && (
+      {((selectedMediaType !== 'video' &&
+        (outputFormat === 'jpeg' || outputFormat === 'webp')) ||
+        selectedMediaType === 'video') && (
         <View style={sharedStyles.qualityRow}>
           <View style={sharedStyles.qualityLabelRow}>
-            <Text style={sharedStyles.qualityLabel}>{t('compressionRate')}</Text>
+            <Text style={sharedStyles.qualityLabel}>
+              {t('compressionRate')}
+            </Text>
             <Text style={sharedStyles.qualityValue}>{compressionRate}%</Text>
           </View>
           <CustomSlider
@@ -243,8 +264,16 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             step={1}
             value={compressionRate}
             onValueChange={(v: number) => onQualityChange(Math.round(v))}
-            accessibilityLabel={selectedMediaType === 'video' ? t('videoCompressionSlider') : t('imageCompressionSlider')}
-            accessibilityHint={selectedMediaType === 'video' ? t('videoCompressionSliderHint') : t('imageCompressionSliderHint')}
+            accessibilityLabel={
+              selectedMediaType === 'video'
+                ? t('videoCompressionSlider')
+                : t('imageCompressionSlider')
+            }
+            accessibilityHint={
+              selectedMediaType === 'video'
+                ? t('videoCompressionSliderHint')
+                : t('imageCompressionSliderHint')
+            }
             minimumTrackTintColor={ACCENT2}
             maximumTrackTintColor={BORDER}
             thumbTintColor={ACCENT2}
@@ -264,7 +293,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
         <Switch
           value={shrinkExpandEnabled}
           onValueChange={onShrinkExpandToggle}
-          trackColor={{false: BORDER, true: ACCENT}}
+          trackColor={{ false: BORDER, true: ACCENT }}
           thumbColor={shrinkExpandEnabled ? '#fff' : '#888'}
         />
       </View>
@@ -302,7 +331,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
         <Switch
           value={multiCompressEnabled}
           onValueChange={onMultiCompressToggle}
-          trackColor={{false: BORDER, true: ACCENT}}
+          trackColor={{ false: BORDER, true: ACCENT }}
           thumbColor={multiCompressEnabled ? '#fff' : '#888'}
         />
       </View>
@@ -310,7 +339,10 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
         <View style={sharedStyles.qualityRow}>
           <View style={sharedStyles.qualityLabelRow}>
             <Text style={sharedStyles.qualityLabel}>{t('compressCount')}</Text>
-            <Text style={sharedStyles.qualityValue}>{multiCompressCount}{t('timesSuffix')}</Text>
+            <Text style={sharedStyles.qualityValue}>
+              {multiCompressCount}
+              {t('timesSuffix')}
+            </Text>
           </View>
           <CustomSlider
             style={sharedStyles.qualitySlider}

--- a/app/src/screens/components/TargetSizePanel.tsx
+++ b/app/src/screens/components/TargetSizePanel.tsx
@@ -1,14 +1,25 @@
 import React from 'react';
-import {View, Text, TouchableOpacity, TextInput, StyleSheet} from 'react-native';
-import {SizeUnit} from '../../state/store';
-import {t} from '../../i18n';
-import {sharedStyles, BORDER, TEXT_SECONDARY, DARK_BG} from './sharedStyles';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  TextInput,
+  StyleSheet,
+} from 'react-native';
 
-const TARGET_SIZE_TEMPLATES: {label: string; value: string; unit: SizeUnit}[] = [
-  {label: 'Discord 10MB', value: '10', unit: 'MB'},
-  {label: 'X (Twitter) 5MB', value: '5', unit: 'MB'},
-  {label: 'LINE 10MB', value: '10', unit: 'MB'},
-  {label: 'Instagram 8MB', value: '8', unit: 'MB'},
+import { sharedStyles, BORDER, TEXT_SECONDARY } from './sharedStyles';
+import { t } from '../../i18n';
+import { SizeUnit } from '../../state/store';
+
+const TARGET_SIZE_TEMPLATES: {
+  label: string;
+  value: string;
+  unit: SizeUnit;
+}[] = [
+  { label: 'Discord 10MB', value: '10', unit: 'MB' },
+  { label: 'X (Twitter) 5MB', value: '5', unit: 'MB' },
+  { label: 'LINE 10MB', value: '10', unit: 'MB' },
+  { label: 'Instagram 8MB', value: '8', unit: 'MB' },
 ];
 
 interface TargetSizePanelProps {
@@ -24,7 +35,7 @@ const TargetSizePanel: React.FC<TargetSizePanelProps> = ({
   onValueChange,
   onUnitChange,
 }) => {
-  const handleTemplateSelect = (tmpl: typeof TARGET_SIZE_TEMPLATES[0]) => {
+  const handleTemplateSelect = (tmpl: (typeof TARGET_SIZE_TEMPLATES)[0]) => {
     onValueChange(tmpl.value);
     onUnitChange(tmpl.unit);
   };
@@ -47,18 +58,31 @@ const TargetSizePanel: React.FC<TargetSizePanelProps> = ({
           {(['KB', 'MB', 'GB'] as SizeUnit[]).map(u => (
             <TouchableOpacity
               key={u}
-              style={[styles.unitButton, targetSizeUnit === u && styles.unitButtonActive]}
+              style={[
+                styles.unitButton,
+                targetSizeUnit === u && styles.unitButtonActive,
+              ]}
               onPress={() => onUnitChange(u)}
               accessibilityRole="button"
               accessibilityLabel={`${t('unitButtonAccessibility')} ${u}`}
-              accessibilityState={{selected: targetSizeUnit === u}}>
-              <Text style={[styles.unitButtonText, targetSizeUnit === u && styles.unitButtonTextActive]}>{u}</Text>
+              accessibilityState={{ selected: targetSizeUnit === u }}
+            >
+              <Text
+                style={[
+                  styles.unitButtonText,
+                  targetSizeUnit === u && styles.unitButtonTextActive,
+                ]}
+              >
+                {u}
+              </Text>
             </TouchableOpacity>
           ))}
         </View>
       </View>
 
-      <Text style={[sharedStyles.sectionTitle, styles.templateTitle]}>{t('template')}</Text>
+      <Text style={[sharedStyles.sectionTitle, styles.templateTitle]}>
+        {t('template')}
+      </Text>
       <View style={styles.targetSizeTemplates}>
         {TARGET_SIZE_TEMPLATES.map(tmpl => (
           <TouchableOpacity
@@ -66,15 +90,16 @@ const TargetSizePanel: React.FC<TargetSizePanelProps> = ({
             style={styles.targetSizeTemplate}
             onPress={() => handleTemplateSelect(tmpl)}
             accessibilityRole="button"
-            accessibilityLabel={`${t('templateButtonAccessibility')} ${tmpl.label}`}>
+            accessibilityLabel={`${t('templateButtonAccessibility')} ${
+              tmpl.label
+            }`}
+          >
             <Text style={styles.targetSizeTemplateText}>{tmpl.label}</Text>
           </TouchableOpacity>
         ))}
       </View>
 
-      <Text style={styles.noteText}>
-        {t('targetSizeNote')}
-      </Text>
+      <Text style={styles.noteText}>{t('targetSizeNote')}</Text>
     </View>
   );
 };

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -1,6 +1,7 @@
-import {create} from 'zustand';
-import {persist, createJSONStorage} from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
 import { ImageFormat } from '../domain/convertImage';
 
 export type VideoFormat = 'mp4' | 'mov' | 'mkv' | 'webm';
@@ -28,7 +29,7 @@ interface AppState {
   // #138 GIF options
   gifFps: number;
   gifScale: number;
-  
+
   setSelectedImage: (image: string | null) => void;
   setSelectedMediaType: (mediaType: 'image' | 'video' | null) => void;
   setResizePercent: (percent: number) => void;
@@ -73,24 +74,25 @@ export const useAppStore = create<AppState>()(
       gifFps: 10,
       gifScale: 100,
 
-      setSelectedImage: image => set({selectedImage: image}),
-      setSelectedMediaType: mediaType => set({selectedMediaType: mediaType}),
-      setResizePercent: percent => set({resizePercent: percent}),
-      setProcessedImage: image => set({processedImage: image}),
-      setIsProcessing: processing => set({isProcessing: processing}),
-      setOutputFormat: format => set({outputFormat: format}),
-      setCompressionRate: rate => set({compressionRate: rate}),
-      setGabigabiLevel: level => set({gabigabiLevel: level}),
-      setVideoOutputFormat: format => set({videoOutputFormat: format}),
-      setShrinkExpandEnabled: enabled => set({shrinkExpandEnabled: enabled}),
-      setShrinkExpandRate: rate => set({shrinkExpandRate: rate}),
-      setMultiCompressEnabled: enabled => set({multiCompressEnabled: enabled}),
-      setMultiCompressCount: count => set({multiCompressCount: count}),
-      setConvertMethod: method => set({convertMethod: method}),
-      setTargetSizeValue: value => set({targetSizeValue: value}),
-      setTargetSizeUnit: unit => set({targetSizeUnit: unit}),
-      setGifFps: fps => set({gifFps: fps}),
-      setGifScale: scale => set({gifScale: scale}),
+      setSelectedImage: image => set({ selectedImage: image }),
+      setSelectedMediaType: mediaType => set({ selectedMediaType: mediaType }),
+      setResizePercent: percent => set({ resizePercent: percent }),
+      setProcessedImage: image => set({ processedImage: image }),
+      setIsProcessing: processing => set({ isProcessing: processing }),
+      setOutputFormat: format => set({ outputFormat: format }),
+      setCompressionRate: rate => set({ compressionRate: rate }),
+      setGabigabiLevel: level => set({ gabigabiLevel: level }),
+      setVideoOutputFormat: format => set({ videoOutputFormat: format }),
+      setShrinkExpandEnabled: enabled => set({ shrinkExpandEnabled: enabled }),
+      setShrinkExpandRate: rate => set({ shrinkExpandRate: rate }),
+      setMultiCompressEnabled: enabled =>
+        set({ multiCompressEnabled: enabled }),
+      setMultiCompressCount: count => set({ multiCompressCount: count }),
+      setConvertMethod: method => set({ convertMethod: method }),
+      setTargetSizeValue: value => set({ targetSizeValue: value }),
+      setTargetSizeUnit: unit => set({ targetSizeUnit: unit }),
+      setGifFps: fps => set({ gifFps: fps }),
+      setGifScale: scale => set({ gifScale: scale }),
     }),
     {
       name: 'gabigabi-app-settings',


### PR DESCRIPTION
## 概要
- SettingsPanel と TargetSizePanel の prettier/import warning を自動整形で解消
- store.ts のフォーマットを揃え、対象3ファイルの lint warning を 91 件から 0 件へ削減
- 未使用 import だった `DARK_BG` を削除

## テスト
- npx eslint src/screens/components/SettingsPanel.tsx src/screens/components/TargetSizePanel.tsx src/state/store.ts
- npm test -- --runInBand src/__tests__/SettingsPanel.test.tsx src/__tests__/TargetSizePanel.test.tsx src/__tests__/useAppStore.test.ts

Closes #227