### PR TITLE
fix: rust_core warningを整理してRust CIを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,17 @@ jobs:
         working-directory: app
         run: npm ci
 
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run Rust tests
+        working-directory: rust_core
+        run: cargo test
+
+      - name: Run Rust clippy
+        working-directory: rust_core
+        run: cargo clippy --all-targets -- -D warnings
+
       - name: Run unit tests
         working-directory: app
         run: npx jest --ci --selectProjects unit

--- a/rust_core/src/lib.rs
+++ b/rust_core/src/lib.rs
@@ -4,8 +4,7 @@
 //! Core image resize library for convert2gabigabi.
 //! 現状はバイト列入力・倍率(%)指定でリサイズした JPEG/PNG バイト列を返す。
 
-use image::{DynamicImage, GenericImageView, ImageFormat};
-use std::io::Cursor;
+use image::GenericImageView;
 use std::slice;
 
 /// Resize the image bytes by `scale_pct` (e.g., 50.0 = 50%) keeping aspect ratio.
@@ -182,7 +181,4 @@ pub extern "C" fn rust_free_buffer(ptr: *mut u8) {
         }
     }
 }
-
-fn detect_format(data: &[u8]) -> anyhow::Result<ImageFormat> {
-    image::guess_format(data).map_err(|e| anyhow::anyhow!(e))
-} 
+ 


### PR DESCRIPTION
## 変更内容
- rust_core の未使用 import と未使用関数を削除
- GitHub Actions に Rust の test / clippy を追加

## 関連Issue
closes #233

## 動作確認
- [x] ローカルでビルド確認済み
- [ ] 実機で動作確認済み

### 実施コマンド
- `cargo test --manifest-path rust_core/Cargo.toml`