### PR TITLE
chore: remove unreachable PR comment step from EAS workflow

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -55,32 +55,3 @@ jobs:
           echo "Build URL: $BUILD_URL"
           echo "Artifact URL: $ARTIFACT_URL"
 
-      - name: Comment QR code on PR
-        if: github.event_name == 'pull_request' && steps.eas-build.outputs.artifact_url != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const artifactUrl = '${{ steps.eas-build.outputs.artifact_url }}';
-            const buildUrl = '${{ steps.eas-build.outputs.build_url }}';
-
-            const qrImageUrl = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(artifactUrl)}`;
-
-            const body = [
-              '## 📱 Android APK ビルド完了',
-              '',
-              'QRコードをスキャンしてAPKをインストールできます。',
-              '',
-              `![QR Code](${qrImageUrl})`,
-              '',
-              `**直接ダウンロード:** [APKをダウンロード](${artifactUrl})`,
-              buildUrl ? `**ビルド詳細:** [EAS Build](${buildUrl})` : '',
-              '',
-              '> ⚠️ インストール前にAndroid設定で「不明なソースからのインストール」を有効にしてください。',
-            ].filter(Boolean).join('\n');
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body,
-            });

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cd app
 eas build --profile preview --platform android
 ```
 
-> CI は手動トリガー (`workflow_dispatch`) のみ。PR や push では自動実行されません。
+> CI は手動トリガー (`workflow_dispatch`) のみです。PR や push では自動実行されず、PR への APK コメント自動投稿も行いません。
 
 ---
 


### PR DESCRIPTION
## 概要
- workflow_dispatch 専用の EAS Build workflow から到達不能な PR コメント step を削除
- README に手動実行専用であることを明記

## 確認
- 設定変更のみのためテスト未実施

Fixes #242