### PR TITLE
fix: satisfy clippy in rust_core build script

### DIFF
--- a/rust_core/build.rs
+++ b/rust_core/build.rs
@@ -8,7 +8,7 @@ fn main() {
     }
     
     // Generate cbindgen headers for C++ bridge
-    if let Ok(_) = cbindgen::generate("./") {
+    if cbindgen::generate("./").is_ok() {
         // cbindgen will generate header files
     }
 } 


### PR DESCRIPTION
## 概要
- `rust_core/build.rs` の `if let Ok(_)` を `is_ok()` に置き換え
- `cargo clippy --all-targets -- -D warnings` で報告される `redundant_pattern_matching` を解消

## 確認
- `cd rust_core && cargo test`
- `cd app && npm ci && npm test -- --runInBand`

Closes #248