### PR TITLE
ci: Node.js 24 既定化に備えてActionsを更新

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: app/package-lock.json
 
@@ -28,7 +28,7 @@ jobs:
         run: npm ci
 
       - name: Setup EAS
-        uses: expo/expo-github-action@v8
+        uses: expo/expo-github-action@v9
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: app/package-lock.json
 


### PR DESCRIPTION
## 概要\n- Node.js 20 runtime 警告の影響がある workflow を棚卸しし、`.github/workflows/test.yml` と `.github/workflows/eas-build.yml` を更新\n- `actions/checkout` を v5、`actions/setup-node` を v6、`expo/expo-github-action` を v9 に更新\n- workflow 上で利用する Node.js も 24 に引き上げて既定変更前の挙動へ揃える\n\n## 確認\n- `cd app && npm ci`\n- `cd app && npm run lint -- --max-warnings 0`\n- `cd app && npx jest --ci --selectProjects unit`\n- `cd app && npx jest --ci --selectProjects integration`\n- `cd rust_core && cargo test`\n- `cd rust_core && cargo clippy --all-targets -- -D warnings` ※この環境では `cargo-clippy` 未導入のため実行不可\n\nCloses #249