### PR TITLE
fix: mark FFI pointer APIs as unsafe

### DIFF
--- a/rust_core/docs/API.md
+++ b/rust_core/docs/API.md
@@ -66,7 +66,7 @@ Android JNI や他言語バインディング用の C 互換関数。
 **シグネチャ**:
 ```rust
 #[no_mangle]
-pub extern "C" fn rust_resize(
+pub unsafe extern "C" fn rust_resize(
     data_ptr: *const u8,
     data_len: usize,
     scale_pct: f32,
@@ -88,6 +88,7 @@ C言語から呼び出し可能な画像リサイズ関数。
 - 失敗時: `null`
 
 **注意**:
+- unsafe FFI 関数のため、`data_ptr` は `data_len` バイト以上読み取り可能で、`output_len` は書き込み可能であること
 - 戻り値のポインタは必ず`rust_free_buffer`で解放すること
 - C側でのメモリ管理が必要
 
@@ -98,7 +99,7 @@ C言語から呼び出し可能な画像リサイズ関数。
 **シグネチャ**:
 ```rust
 #[no_mangle]
-pub extern "C" fn rust_free_buffer(ptr: *mut u8, len: usize)
+pub unsafe extern "C" fn rust_free_buffer(ptr: *mut u8)
 ```
 
 **説明**:  
@@ -106,10 +107,9 @@ pub extern "C" fn rust_free_buffer(ptr: *mut u8, len: usize)
 
 **パラメータ**:
 - `ptr: *mut u8` - 解放するメモリのポインタ
-- `len: usize` - メモリサイズ
 
 **注意**:
-- `rust_resize`で取得したポインタのみ解放可能
+- unsafe FFI 関数のため、`rust_resize`で取得したポインタのみ解放可能
 - 二重解放禁止
 
 ---

--- a/rust_core/src/lib.rs
+++ b/rust_core/src/lib.rs
@@ -148,8 +148,13 @@ fn encode_gabigabi_jpeg_quality(img: &image::RgbImage, output: &mut Vec<u8>, qua
 }
 
 /// C-compatible resize function for FFI
+///
+/// # Safety
+/// `data` must point to a readable buffer of `len` bytes.
+/// `out_len` must be a valid writable pointer.
+/// The returned pointer must be released with `rust_free_buffer`.
 #[no_mangle]
-pub extern "C" fn rust_resize(
+pub unsafe extern "C" fn rust_resize(
     data: *const u8,
     len: usize,
     scale_pct: f32,
@@ -158,9 +163,9 @@ pub extern "C" fn rust_resize(
     if data.is_null() || out_len.is_null() {
         return std::ptr::null_mut();
     }
-    
+
     let input_slice = unsafe { slice::from_raw_parts(data, len) };
-    
+
     match resize(input_slice, scale_pct) {
         Ok(result) => {
             let result_len = result.len();
@@ -173,8 +178,11 @@ pub extern "C" fn rust_resize(
 }
 
 /// Free memory allocated by rust_resize
+///
+/// # Safety
+/// `ptr` must be a pointer returned by `rust_resize`, and it must not be freed twice.
 #[no_mangle]
-pub extern "C" fn rust_free_buffer(ptr: *mut u8) {
+pub unsafe extern "C" fn rust_free_buffer(ptr: *mut u8) {
     if !ptr.is_null() {
         unsafe {
             let _ = Box::from_raw(ptr);

--- a/rust_core/tests/integration_test.rs
+++ b/rust_core/tests/integration_test.rs
@@ -22,19 +22,21 @@ fn test_resize_invalid_scale() {
 
 #[test]
 fn test_resize_ffi_functions() {
-    use rust_core::{rust_resize, rust_free_buffer};
-    
+    use rust_core::{rust_free_buffer, rust_resize};
+
     let mut out_len: usize = 0;
-    let result_ptr = rust_resize(
-        SAMPLE_PNG.as_ptr(),
-        SAMPLE_PNG.len(),
-        75.0,
-        &mut out_len as *mut usize,
-    );
-    
+    let result_ptr = unsafe {
+        rust_resize(
+            SAMPLE_PNG.as_ptr(),
+            SAMPLE_PNG.len(),
+            75.0,
+            &mut out_len as *mut usize,
+        )
+    };
+
     assert!(!result_ptr.is_null(), "FFI resize should return valid pointer");
     assert!(out_len > 0, "Output length should be positive");
-    
+
     // Free the allocated memory
-    rust_free_buffer(result_ptr);
+    unsafe { rust_free_buffer(result_ptr) };
 } 


### PR DESCRIPTION
## 概要
- `rust_resize` と `rust_free_buffer` を `unsafe extern "C" fn` に変更し、FFI の安全性契約を doc comment に明記
- Rust 側の FFI テスト呼び出しを `unsafe` ブロックで包み、API 変更に追従
- API ドキュメントも新しいシグネチャと前提条件に更新

## 確認
- `cd rust_core && cargo test`
- `cargo clippy --all-targets -- -D warnings` はローカル Fedora 環境に `cargo-clippy` が未導入のため未実行

Closes #252
