### PR TITLE
docs: fix #259

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ cd app && npx react-native start
 - [ ] `domain/` → `data/` の依存方向になっているか（逆は NG）
 - [ ] `expo-file-system` を使っているか（`react-native-fs` ではなく）
 - [ ] 新しいネイティブパッケージを追加した場合、ドキュメントに記載したか
-- [ ] `docs/tasklist.md` に変更を反映したか
+- [ ] 関連ドキュメント（README、docs配下、運用ガイド）に必要な更新を反映したか
 - [ ] コミットメッセージに `fix:`, `feat:`, `docs:`, `chore:` 等のプレフィックスをつけたか
 
 ---


### PR DESCRIPTION
## 概要
- issue #259 のドキュメント不整合を修正

## 変更内容
- 参照切れやリポジトリ名の不一致を現状に合わせて更新

## テスト
- ドキュメント変更のみのため未実施
