### PR TITLE
fix: CI test file lint warnings

### DIFF
--- a/app/__tests__/App.test.tsx
+++ b/app/__tests__/App.test.tsx
@@ -4,10 +4,12 @@
 
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
+
 import App from '../App';
 
 jest.mock('@react-navigation/native', () => ({
-  NavigationContainer: ({ children }: { children: React.ReactNode }) => children,
+  NavigationContainer: ({ children }: { children: React.ReactNode }) =>
+    children,
 }));
 
 jest.mock('@react-navigation/native-stack', () => ({

--- a/app/src/__tests__/integration.test.ts
+++ b/app/src/__tests__/integration.test.ts
@@ -7,8 +7,8 @@
 
 import { execSync } from 'child_process';
 import * as fs from 'fs';
-import * as path from 'path';
 import * as os from 'os';
+import * as path from 'path';
 
 const FIXTURES_DIR = path.join(__dirname, '..', '..', 'fixtures');
 const INPUT_MP4 = path.join(FIXTURES_DIR, 'test.mp4');
@@ -48,7 +48,9 @@ describeIfFfmpeg('ffmpeg integration tests', () => {
     const outputFile = path.join(tmpDir, `output.${outputExt}`);
     // mpg (MPEG-1) requires standard frame rates (e.g. 25fps); upsample if needed
     const extraArgs = outputExt === 'mpg' ? '-r 25' : '';
-    execSync(`ffmpeg -i "${inputFile}" ${extraArgs} "${outputFile}" -y`, { stdio: 'pipe' });
+    execSync(`ffmpeg -i "${inputFile}" ${extraArgs} "${outputFile}" -y`, {
+      stdio: 'pipe',
+    });
 
     // ファイルが存在すること
     expect(fs.existsSync(outputFile)).toBe(true);


### PR DESCRIPTION
## Summary

Jest Tests で失敗していたテスト用ファイルの ESLint warning を解消しました。

## Changes

- `app/__tests__/App.test.tsx` の import 順と折り返しを整形
- `app/src/__tests__/integration.test.ts` の import 順と `execSync` 呼び出しを整形

## Testing

- `npm run lint -- --max-warnings 0`
- `npm test -- --runInBand`

Fixes e-komiya/gabigabi#267
