### PR TITLE
fix: Expo SDK 56 通知・共有回帰のエラーハンドリングを補強

### DIFF
--- a/app/src/__tests__/ConversionHistoryModal.test.tsx
+++ b/app/src/__tests__/ConversionHistoryModal.test.tsx
@@ -590,4 +590,51 @@ describe('共有機能 (Issue #165)', () => {
       expect.stringContaining('sample_out.jpg'),
     );
   });
+
+  it('共有機能が利用できない場合はエラーを表示する', async () => {
+    Sharing.isAvailableAsync.mockResolvedValue(false);
+    const renderer = await createWithData([sampleItem]);
+    await ReactTestRenderer.act(async () => {});
+
+    const shareBtn = renderer.root.findAll(
+      (node: ReactTestRenderer.ReactTestInstance) =>
+        node.props.accessibilityRole === 'button' &&
+        (node.props.accessibilityLabel === 'Share file' ||
+          node.props.accessibilityLabel === 'ファイルを共有'),
+    )[0];
+
+    await ReactTestRenderer.act(async () => {
+      shareBtn.props.onPress?.();
+    });
+
+    expect(Sharing.shareAsync).not.toHaveBeenCalled();
+    expect(Alert.alert).toHaveBeenCalledWith(
+      expect.stringMatching(/Error|エラー/),
+      expect.stringMatching(
+        /Sharing is not available on this device|この端末では共有機能を利用できません/,
+      ),
+    );
+  });
+
+  it('共有時にキャンセル以外のエラーが起きた場合は詳細を表示する', async () => {
+    Sharing.shareAsync.mockRejectedValue(new Error('boom'));
+    const renderer = await createWithData([sampleItem]);
+    await ReactTestRenderer.act(async () => {});
+
+    const shareBtn = renderer.root.findAll(
+      (node: ReactTestRenderer.ReactTestInstance) =>
+        node.props.accessibilityRole === 'button' &&
+        (node.props.accessibilityLabel === 'Share file' ||
+          node.props.accessibilityLabel === 'ファイルを共有'),
+    )[0];
+
+    await ReactTestRenderer.act(async () => {
+      shareBtn.props.onPress?.();
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      expect.stringMatching(/Error|エラー/),
+      expect.stringMatching(/Failed to share|共有に失敗しました/),
+    );
+  });
 });

--- a/app/src/__tests__/i18n.test.ts
+++ b/app/src/__tests__/i18n.test.ts
@@ -32,6 +32,7 @@ describe('i18n', () => {
         'saveSuccess',
         'saveFailed',
         'shareFailed',
+        'shareUnavailable',
         'invalidTargetSize',
         'targetCompressionFailed',
         'appSubtitle',
@@ -112,7 +113,7 @@ describe('i18n', () => {
         'targetSizeNotReachedSuffix',
       ];
 
-      expect(keys).toHaveLength(103);
+      expect(keys).toHaveLength(104);
 
       for (const key of keys) {
         const result = t(key);

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -45,6 +45,10 @@ const DICT: Dict = {
   saveSuccess: { ja: '保存完了', en: 'Saved' },
   saveFailed: { ja: '保存に失敗しました', en: 'Failed to save' },
   shareFailed: { ja: '共有に失敗しました', en: 'Failed to share' },
+  shareUnavailable: {
+    ja: 'この端末では共有機能を利用できません',
+    en: 'Sharing is not available on this device',
+  },
   invalidTargetSize: {
     ja: '有効な目標サイズを入力してください',
     en: 'Please enter a valid target size.',

--- a/app/src/screens/components/ConversionHistoryModal.tsx
+++ b/app/src/screens/components/ConversionHistoryModal.tsx
@@ -183,10 +183,15 @@ const HistoryItem: React.FC<{
       : `file://${item.outputPath}`;
     try {
       const isAvailable = await Sharing.isAvailableAsync();
-      if (!isAvailable) return;
+      if (!isAvailable) {
+        Alert.alert(t('error'), t('shareUnavailable'));
+        return;
+      }
       await Sharing.shareAsync(path);
-    } catch {
-      // 共有に失敗した場合は無視
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('cancel')) return;
+      Alert.alert(t('error'), `${t('shareFailed')}: ${message}`);
     }
   }, [item.outputPath]);
 

--- a/docs/expo-sdk-56-notifications-sharing-regression.md
+++ b/docs/expo-sdk-56-notifications-sharing-regression.md
@@ -1,0 +1,67 @@
+# Expo SDK 56 通知・共有フロー確認メモ
+
+issue: #286
+
+最終更新: 2026-06-16 (Asia/Tokyo)
+
+## 今回の確認対象
+
+- `expo-notifications` の権限取得と Android 通知チャンネル初期化
+- `expo-sharing` を使う変換履歴からの共有導線
+- Expo SDK 56 土台更新後の native 設定差分の記録
+
+## コード確認結果
+
+### 通知
+
+対象: `app/src/hooks/useProcessingNotification.ts`
+
+- 通知表示前に `Notifications.getPermissionsAsync()` を確認している
+- 未許可時のみ `Notifications.requestPermissionsAsync()` を呼ぶ
+- Android では `processing-status` チャンネルを初期化している
+- 進行中通知の更新時は前回通知を `dismissNotificationAsync` で閉じてから再通知している
+
+### 共有
+
+対象: `app/src/screens/components/ConversionHistoryModal.tsx`
+
+- 変換履歴の出力ファイルを `file://` URI に正規化して共有している
+- `Sharing.isAvailableAsync()` が `false` の場合にエラー表示を追加した
+- `Sharing.shareAsync()` 失敗時はキャンセルを除いてエラー詳細を表示するようにした
+
+## native 設定差分メモ
+
+### `app/app.json`
+
+- `plugins` に `expo-sharing` が追加済み
+- `android.adaptiveIcon` と `icon` の参照先は未整備アセットに依存しているため、prebuild 失敗要因として継続管理が必要
+
+### `app/android/app/src/main/AndroidManifest.xml`
+
+- `POST_NOTIFICATIONS` 権限が定義済み
+- 通知用 `default_notification_icon` の meta-data が定義済み
+- `FOREGROUND_SERVICE` 系権限も維持されている
+
+## テスト
+
+```bash
+cd app
+npm test -- --runInBand -- ConversionHistoryModal useProcessingNotification i18n
+npm run lint
+```
+
+確認観点:
+
+- 通知権限あり/なしの分岐
+- 通知更新時の dismiss 挙動
+- 共有成功時の `shareAsync` 呼び出し
+- 共有不可端末と共有失敗時のエラー表示
+
+## 未実施 / 継続事項
+
+この実行環境では Android 実機確認までは未実施。
+次回は以下を実機で確認する。
+
+1. Android 13+ で初回通知権限ダイアログが期待通りに出ること
+2. 変換後の画像と動画が共有シートから正常に共有できること
+3. Expo prebuild を通すための `assets/icon.png` など不足アセット整理


### PR DESCRIPTION
## 概要
- Expo SDK 56 移行後の共有フローで、共有不可端末と共有失敗時のハンドリングを追加
- 通知/共有まわりの回帰確認メモを docs に整理
- 共有まわりの回帰テストを追加

## 変更内容
- `ConversionHistoryModal` で `expo-sharing` 非対応端末時にエラー表示を追加
- 共有エラー時はキャンセルを除いて詳細付きアラートを表示
- `docs/expo-sdk-56-notifications-sharing-regression.md` を追加し、通知権限, channel, native 設定差分の確認結果を記録
- `ConversionHistoryModal` / `i18n` テストを更新

## テスト
- `cd app && npm test -- --runInBand -- ConversionHistoryModal useProcessingNotification i18n`
- `cd app && npm run lint`

## 補足
- Android 実機での通知権限ダイアログと共有シート確認は未実施のため、次回実機確認が必要
- `npx expo prebuild --platform android --clean` は引き続き不足アセットで失敗するため別途整理が必要

Fixes #286