### PR TITLE
docs: sync version references with current package metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,11 @@ app/src/
 
 ## 🛠️ 技術スタック
 
+> バージョン表記の正本は `app/package.json` とし、このガイドの記述もそれに合わせて保守する。
+
 | 項目 | 内容 |
 |---|---|
-| フレームワーク | React Native 0.83 + Expo SDK 55 |
+| フレームワーク | React Native 0.83.2 + Expo SDK 55 |
 | 言語 | TypeScript 5.x |
 | 画像処理 | FFmpegKit (`ffmpeg-kit-react-native`) |
 | 補助処理 | Rust (`rust_core/`) + JNI |

--- a/README.md
+++ b/README.md
@@ -103,9 +103,11 @@ data/ffmpeg    data/native
 
 ## 技術スタック
 
+> 依存バージョンの正本は `app/package.json` です。README 内の技術スタック表もそれに追従します。
+
 | カテゴリ | 採用技術 |
 |---|---|
-| UI フレームワーク | React Native 0.83 + Expo SDK 55 |
+| UI フレームワーク | React Native 0.83.2 + Expo SDK 55 |
 | 言語 | TypeScript 5.x |
 | 画像処理 | FFmpegKit (`ffmpeg-kit-react-native`) |
 | 補助処理 | Rust (`image` crate) + JNI ブリッジ |

--- a/docs/local-dev-android.md
+++ b/docs/local-dev-android.md
@@ -100,7 +100,9 @@ npx expo run:android
 このプロジェクトは `expo-dev-client` を使っているため、**Expo Goアプリでは動作しません**。
 必ず `npx expo run:android` でカスタムdev clientをビルドしてください。
 
-### RN 0.80 + Hermesの既知バグ（`require` エラー）
+### RN 0.80 系で確認した Hermes既知バグ（`require` エラー）
+
+> 補足: 現在の `app/package.json` は React Native 0.83.2 です。この節は 0.80 系で遭遇した事象のメモとして残しています。
 
 **症状：** アプリ起動時に赤いエラー画面で以下が表示される
 ```
@@ -108,7 +110,7 @@ Property 'require' doesn't exist
 ReferenceError: Property 'require' doesn't exist
 ```
 
-**原因：** React Native 0.80のデフォルト設定（`lazy=true` + New Architecture）との組み合わせ問題
+**原因：** React Native 0.80 系のデフォルト設定（`lazy=true` + New Architecture）との組み合わせで起きやすい問題
 
 **対処法1: `gradle.properties` の修正**
 ```bash

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -4,11 +4,13 @@
 端末内およびクリップボードの JPEG/PNG 画像を、ユーザーが指定した縮小率で低解像度へ変換する Android アプリ。
 
 ## 言語
-- **TypeScript 5.x + React Native 0.73**  
+- **TypeScript 5.x + React Native 0.83.2 (Expo SDK 55)**  
   型安全な JS 環境。クロスプラットフォーム UI を実装。
 
+> 現在の依存バージョンの正本は `app/package.json` とし、この文書はそれに合わせて更新する。
+
 ## UI
-- **React Native + React Navigation 7 + Material 3 Design**  
+- **React Native 0.83 系 + React Navigation 7 + Material 3 Design**  
   宣言的 UI。Expo Vector Icons でシンプルな白基調デザイン。
 
 ## 画像処理


### PR DESCRIPTION
## Summary
- make README and AGENTS explicitly follow app/package.json as the source of truth
- update docs/stack.md to reflect React Native 0.83.2 + Expo SDK 55
- clarify the RN 0.80 Hermes note as historical context

## Testing
- not run (docs only)

Closes #289