### PR TITLE
docs: refresh dependency audit inventory

### DIFF
--- a/docs/dependency-audit-status-2026-06.md
+++ b/docs/dependency-audit-status-2026-06.md
@@ -1,30 +1,28 @@
 # app 依存の監査状況メモ (2026-06)
 
-最終更新: 2026-06-18 (Asia/Tokyo)
+最終更新: 2026-06-19 (Asia/Tokyo)
 対象: `app/package.json`, `app/package-lock.json`
 
 ## 背景
 
-同一メジャー更新と React Native CLI の緊急更新を取り込んだ後でも、`npm audit` では Expo 系を中心に moderate 以上の脆弱性が残っています。
-このメモは、現時点で残っているものを「今の SDK 55 系で消せるもの」と「SDK 56 移行前提のもの」に分けて、次の着手単位を固定するためのものです。
+Expo SDK 56 反映と React Native CLI の緊急更新を取り込んだ後でも、`npm audit` では Expo 系を中心に moderate 以上の脆弱性が残っています。
+このメモは、現時点で残っているものを「アプリ側ですぐ消せる可能性があるもの」と「upstream 追従待ちのもの」に分けて、次の着手単位を固定するためのものです。
 
 ## 実施コマンド
 
 ```bash
 cd app
+npm audit --omit=dev --json
 npm audit --json
 npm outdated --json
 ```
 
 ## 現在のサマリ
 
-2026-06-17 時点の `npm audit` 件数:
+2026-06-19 時点の `npm audit` 件数:
 
-- critical: 0
-- high: 5
-- moderate: 15
-- low: 2
-- total: 22
+- `npm audit --omit=dev --json`: critical 0 / high 0 / moderate 11 / low 2 / total 13
+- `npm audit --json`: critical 0 / high 0 / moderate 12 / low 2 / total 14
 
 ## 既に反映済みの改善
 
@@ -111,25 +109,46 @@ npm outdated --json
 - Expo 系の moderate は引き続き `@expo/config-plugins -> xcode -> uuid` 連鎖に集中しており、アプリ側 override だけで安全に片付ける根拠が薄い
 - `ajv` は fix が v8 系前提で、`eslint@8` 周辺の互換性確認なしに override するのはリスクが高い
 
+## 2026-06-19 issue #299 対応結果
+
+実施内容:
+- `npm audit --omit=dev --json` と `npm audit --json` を再実行し、prod と dev を分けて残件を再棚卸し
+- `package-lock.json` から `ajv`, `compression`, `on-headers`, `@expo/config-plugins`, `xcode`, `uuid` の依存元を再確認
+- 残件を 3 つの次アクション, つまり `ajv` 検証, `compression` / `on-headers` 追跡, Expo upstream 追跡に分解
+
+依存元の再整理:
+- `ajv@6.12.6`: `eslint@8.57.1`, `@eslint/eslintrc@2.1.4`
+- `compression@1.8.0`: `@expo/cli@56.1.16`, `@react-native-community/cli-server-api@20.1.3`
+- `on-headers@1.0.2`: `compression@1.8.0`
+- `@expo/config-plugins@56.0.9`: `expo@56.0.12`, `expo-sharing@56.0.18` など
+- `xcode@3.0.1`: `@expo/config-plugins@56.0.9`
+- `uuid@7.0.3`: `xcode@3.0.1`
+
+判断:
+- prod 残件は依然として Expo 設定系が中心で、アプリコード単体の修正だけで減らせる余地は小さい
+- `ajv` は dev 限定なので、lint 系の更新検証を独立作業として扱うのが安全
+- `compression` / `on-headers` は low かつ CLI 系の共通依存なので、upstream 更新可否の監視を優先する
+
 ## 今回の結論
 
-- critical はすでに解消済みで、残件は Expo 系 moderate と一部の開発系 moderate に絞られた
-- Expo 系の残存脆弱性は、SDK 55 のまま小手先で消すより SDK 56 移行計画とセットで扱う方が安全
-- 残件は「すぐ全部直す」ではなく、次の 2 系統に分割して進める
+- critical / high は解消済みで、残件は Expo 系 moderate と少数の dev / low 依存に絞られた
+- prod 観点の残件は `@expo/config-plugins -> xcode -> uuid` を含む Expo 設定系連鎖が主因
+- 残件は「一括修正」ではなく、次の 3 系統に分割して進める
 
-1. Expo SDK 56 移行の前提整理と段階分割
-2. 開発系ツールチェーン更新の切り分け
+1. `ajv` を含む ESLint 系更新可否の確認
+2. `compression` / `on-headers` の CLI 依存更新可否の確認
+3. Expo / `expo-sharing` / `config-plugins` / `xcode` / `uuid` の upstream 追跡
 
 ## 次に切る PR 単位
 
-1. Expo SDK 56 に上げるための依存更新 PR
-2. `expo-notifications` / `expo-sharing` の追従確認 PR
-3. `@xmldom/xmldom` / `ws` を引いている開発系依存の更新可否を検証する PR
+1. `ajv` を含む ESLint 系更新可否を検証する PR
+2. `compression` / `on-headers` の CLI 依存更新可否を確認する PR
+3. Expo upstream 追跡メモを更新する PR
 
 ## 完了条件
 
 この issue は以下を満たしたら完了とする。
 
-- 2026-06-17 時点の残存監査項目が文書化されている
-- critical 解消後に残った群が整理されている
+- 2026-06-19 時点の残存監査項目が prod / dev 別に文書化されている
+- アプリ側で先に触れる候補と upstream 追従待ちの候補が分離されている
 - 次に作る PR 単位が明文化されている

--- a/docs/expo-56-moderate-audit-reevaluation-2026-06.md
+++ b/docs/expo-56-moderate-audit-reevaluation-2026-06.md
@@ -1,4 +1,4 @@
-# Expo 56 反映後の moderate 監査再評価 (2026-06-18)
+# Expo 56 反映後の moderate 監査再評価 (2026-06-19)
 
 対象: `app/package.json`, `app/package-lock.json`
 
@@ -6,14 +6,16 @@
 
 ```bash
 cd app
+npm audit --omit=dev --json
 npm audit --json
 npm ls expo expo-sharing @expo/config-plugins xcode uuid --all
 ```
 
 ## 前提
 
-- issue #293 の `overrides` 対応後、`npm audit` は `high 0 / moderate 15 / low 2 / total 17`
-- 残る moderate は Expo 設定系の依存連鎖と、その周辺の古いユーティリティに集中している
+- issue #297 までの対応後、`npm audit --json` は `high 0 / moderate 12 / low 2 / total 14`
+- 2026-06-19 時点の `npm audit --omit=dev --json` は `high 0 / moderate 11 / low 2 / total 13`
+- 残る moderate は Expo 設定系の依存連鎖に集中し、non-dev で見ると `ajv` は除外される
 
 ## 残存 moderate の整理
 
@@ -33,42 +35,40 @@ npm ls expo expo-sharing @expo/config-plugins xcode uuid --all
 - `expo@56.0.12` と `expo-sharing@56.0.18` はいずれも `@expo/config-plugins@56.0.9` を共有している
 - `@expo/config-plugins@56.0.9` は `xcode@3.0.1` を引き、その先で `uuid@7.0.3` が残る
 - `expo-sharing` 側は `@expo/plist -> @xmldom/xmldom` も持つが、これは issue #293 の override で吸収済み
-- `npm audit` の `fixAvailable` は Expo 46 など非現実的な候補を返しており、そのまま採用不可
+- `npm audit` の `fixAvailable` は `expo@46.0.21` や `expo-sharing@14.0.8` のような非現実的な候補を返しており、そのまま採用不可
 
 判断:
 - Expo 56 系の同一メジャー内で lockfile を揺らしても、`config-plugins -> xcode -> uuid` 連鎖は upstream 側更新待ちの可能性が高い
 - アプリ側の直接依存だけで片付く粒度ではなく、Expo 本体または `expo-sharing` が新しい `config-plugins` を取り込むまで据え置き候補
 
-### 2. Expo 非依存で個別更新できるもの
+### 2. Expo 非依存で個別更新を再確認したもの
 
 - `ajv`
-- `brace-expansion`
 - `compression`
 - `on-headers`
-- `js-yaml`
-- `yaml`
 
 観測:
-- `brace-expansion`, `js-yaml`, `yaml` は override だけで更新でき、2026-06-18 の issue #297 対応で実際に解消できた
-- `compression` / `on-headers` は low で、React Native CLI 側の追従を待っても優先度は低い
-- `ajv` は `eslint -> @eslint/eslintrc` 配下の v6 依存で、fixAvailable が v8 系を指すため互換性確認なしの override は避けたい
+- `ajv@6.12.6` は `eslint@8.57.1` と `@eslint/eslintrc@2.1.4` から参照されており、prod 監査には出ない
+- `compression@1.8.0` は `@expo/cli@56.1.16` と `@react-native-community/cli-server-api@20.1.3` の双方から参照されている
+- `on-headers@1.0.2` は `compression@1.8.0` 配下で残っている
+- `brace-expansion`, `js-yaml`, `yaml` は issue #297 で解消済み
 
 判断:
-- Expo 連鎖とは分離して扱えるもののうち、まず `brace-expansion`, `js-yaml`, `yaml` を先行で減らすのが安全
-- `ajv` は ESLint 系の更新や upstream 追従とセットで扱う方が無難
+- `ajv` は dev 依存に閉じているので、次回は ESLint 系更新可否の確認を単独 issue として切り出すのが妥当
+- `compression` / `on-headers` は low かつ Expo CLI と React Native CLI の共通下位依存なので、override を急ぐより upstream 追従確認を優先する
 
 ## 追加更新で減らせるもの / 据え置くもの
 
-### 追加更新で減らせる可能性が高いもの
+### 追加更新で減らせる可能性があるもの
 
 - `ajv`
 - `compression`
 - `on-headers`
 
 理由:
-- `brace-expansion`, `js-yaml`, `yaml` は issue #297 で解消済み
-- 残る `ajv` は技術的には候補だが、ESLint 系の互換性確認が前提
-- `compression` / `on-headers` は low のため、優先度は一段低い
+- `ajv` は dev 依存なので、解消価値はあるがリリース阻害度は高くない
+- `compression` / `on-headers` は prod 監査に残る low だが、依存元が CLI 側に寄っておりアプリ本体コードからは触りにくい
+- いずれも「まず separate issue で更新条件を固定し、その後 PR 化」の順が安全
 
 ### 現状据え置くもの
 
@@ -89,11 +89,13 @@ npm ls expo expo-sharing @expo/config-plugins xcode uuid --all
 
 ## 次の PR 粒度
 
-1. non-Expo moderate を `overrides` で減らせるか検証する PR
-2. Expo / `expo-sharing` / `config-plugins` の upstream 更新可否を追跡するメモ更新 PR
+1. `ajv` を含む ESLint 系更新可否を検証する PR
+2. `compression` / `on-headers` の CLI 依存更新可否を確認する PR
+3. Expo / `expo-sharing` / `config-plugins` / `xcode` / `uuid` の upstream 追跡メモ更新 PR
 
 ## 結論
 
-- Expo 56 反映後も残る moderate の主因は `@expo/config-plugins -> xcode -> uuid` 連鎖
-- non-Expo moderate のうち `brace-expansion`, `js-yaml`, `yaml` は issue #297 で先行解消できた
-- 次に着手するべき実装単位は「Expo upstream 追従待ちの残件整理」と「ajv を ESLint 系更新込みで扱うかの判断」
+- 2026-06-19 時点で `npm audit --omit=dev` の残件は `moderate 11 / low 2 / total 13`
+- prod 残件の主因は `@expo/config-plugins -> xcode -> uuid` を含む Expo 設定系連鎖
+- dev を含めると `ajv@6.12.6` が 1 件追加されるが、これは `eslint` 系の更新判断とセットで扱うのが妥当
+- 次に着手するべき実装単位は「Expo upstream 追従待ちの残件整理」「CLI 配下 low 依存の更新条件整理」「ajv を ESLint 系更新込みで扱うかの判断」


### PR DESCRIPTION
## 概要
- `npm audit --omit=dev --json` と `npm audit --json` の結果を 2026-06-19 時点で更新
- `ajv`, `compression`, `on-headers`, Expo 設定系連鎖の依存元を docs に追記
- 次の作業単位を issue #300, #301, #302 に分割

## 確認
- docs 更新のみのため未実施

Fixes #299