### PR TITLE
web-server.js の構文エラーで lint 失敗を防ぐ

### DIFF
--- a/app/web-server.js
+++ b/app/web-server.js
@@ -30,6 +30,6 @@ app.get('/', (req, res) => {
 });
 
 app.listen(PORT, () => {
-  console.log(`🚀 Web server running at http://localhost:${PORT}`);
+  console.log('🚀 Web server running at http://localhost:' + PORT);
   console.log('📱 convert2gabigabi UI is ready!');
 });


### PR DESCRIPTION
## 概要
- web-server.js の起動ログを文字列連結に変更
- テンプレートリテラル解釈に依存しない形にして lint のパース失敗を避ける

## 検証
- npm ci
- npx eslint web-server.js -f unix
- npm run lint -- web-server.js

Closes #307