### PR TITLE
docs: sync current Expo and React Native versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ app/src/
 
 | 項目 | 内容 |
 |---|---|
-| フレームワーク | React Native 0.83.2 + Expo SDK 55 |
-| 言語 | TypeScript 5.x |
+| フレームワーク | React Native 0.85.3 + Expo SDK 56 |
+| 言語 | TypeScript 6.x |
 | 画像処理 | FFmpegKit (`ffmpeg-kit-react-native`) |
 | 補助処理 | Rust (`rust_core/`) + JNI |
 | 状態管理 | Zustand 5.x |

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ data/ffmpeg    data/native
 
 | カテゴリ | 採用技術 |
 |---|---|
-| UI フレームワーク | React Native 0.83.2 + Expo SDK 55 |
-| 言語 | TypeScript 5.x |
+| UI フレームワーク | React Native 0.85.3 + Expo SDK 56 |
+| 言語 | TypeScript 6.x |
 | 画像処理 | FFmpegKit (`ffmpeg-kit-react-native`) |
 | 補助処理 | Rust (`image` crate) + JNI ブリッジ |
 | 状態管理 | Zustand |

--- a/docs/local-dev-android.md
+++ b/docs/local-dev-android.md
@@ -102,7 +102,7 @@ npx expo run:android
 
 ### RN 0.80 系で確認した Hermes既知バグ（`require` エラー）
 
-> 補足: 現在の `app/package.json` は React Native 0.83.2 です。この節は 0.80 系で遭遇した事象のメモとして残しています。
+> 補足: 現在の `app/package.json` は React Native 0.85.3 / Expo SDK 56 です。この節は 0.80 系で遭遇した事象のメモとして残しています。
 
 **症状：** アプリ起動時に赤いエラー画面で以下が表示される
 ```

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -4,13 +4,13 @@
 端末内およびクリップボードの JPEG/PNG 画像を、ユーザーが指定した縮小率で低解像度へ変換する Android アプリ。
 
 ## 言語
-- **TypeScript 5.x + React Native 0.83.2 (Expo SDK 55)**  
+- **TypeScript 6.x + React Native 0.85.3 (Expo SDK 56)**  
   型安全な JS 環境。クロスプラットフォーム UI を実装。
 
 > 現在の依存バージョンの正本は `app/package.json` とし、この文書はそれに合わせて更新する。
 
 ## UI
-- **React Native 0.83 系 + React Navigation 7 + Material 3 Design**  
+- **React Native 0.85 系 + React Navigation 7 + Material 3 Design**  
   宣言的 UI。Expo Vector Icons でシンプルな白基調デザイン。
 
 ## 画像処理


### PR DESCRIPTION
## 概要
- README / AGENTS / docs/stack の Expo / React Native / TypeScript 表記を現行依存へ更新
- local-dev-android の補足を React Native 0.85.3 / Expo SDK 56 に更新
- 過去の RN 0.80 系メモが現状説明と誤読されにくい形に調整

Closes #311